### PR TITLE
fix(media): make opus_mlow codec thread-safe

### DIFF
--- a/internal/voip/media/codec_concurrency_test.go
+++ b/internal/voip/media/codec_concurrency_test.go
@@ -1,0 +1,91 @@
+//go:build mlow
+
+package media
+
+import (
+	"math"
+	"sync"
+	"testing"
+)
+
+// These tests guard the thread-safety of the bundled opus_mlow library.
+// In a live call, Encode (uplink) and Decode (downlink) run on different
+// goroutines against the same codec object. The native library is not
+// thread-safe, so the codec implementation must serialize every C call;
+// without that, concurrent Encode/Decode crashes the process
+// ("fatal error: semasleep on Darwin signal stack").
+
+func testTone(n int, freq, rate float64) []float32 {
+	f := make([]float32, n)
+	for i := range f {
+		f[i] = 0.3 * float32(math.Sin(2*math.Pi*freq*float64(i)/rate))
+	}
+	return f
+}
+
+func hammerEncodeDecode(t *testing.T, c Codec, frame []float32) {
+	t.Helper()
+	seed, err := c.Encode(frame)
+	if err != nil {
+		t.Fatalf("seed encode: %v", err)
+	}
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 2000; i++ {
+				_, _ = c.Encode(frame)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 2000; i++ {
+				_, _ = c.Decode(seed)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// Opus 48 kHz codec (browser side): Encode runs on the relay goroutine
+// (OnPeerAudio) while Decode runs on the bridge goroutine (OnBrowserRTP).
+func TestOpus48ConcurrentEncodeDecode(t *testing.T) {
+	c, err := NewOpusCodec(48000, 960)
+	if err != nil {
+		t.Fatalf("NewOpusCodec: %v", err)
+	}
+	defer c.Close()
+	hammerEncodeDecode(t, c, testTone(2880, 440, 48000)) // 60 ms @ 48k
+}
+
+// MLow codec (WhatsApp side): Encode runs under the CallManager lock
+// (FeedCapturedPCM / keepalive) while Decode runs from onRelayData.
+func TestMLowConcurrentEncodeDecode(t *testing.T) {
+	c, err := NewMLowCodec(DefaultCodecOptions)
+	if err != nil {
+		t.Fatalf("NewMLowCodec: %v", err)
+	}
+	defer c.Close()
+	hammerEncodeDecode(t, c, testTone(960, 440, 16000))
+}
+
+// The Opus 48 kHz roundtrip is otherwise uncovered; it exercises the exact
+// frame size produced by Upsample16to48 of a 960-sample 16 kHz frame.
+func TestOpus48Roundtrip(t *testing.T) {
+	c, err := NewOpusCodec(48000, 960)
+	if err != nil {
+		t.Fatalf("NewOpusCodec: %v", err)
+	}
+	defer c.Close()
+	frame := testTone(2880, 440, 48000)
+	for i := 0; i < 500; i++ {
+		enc, err := c.Encode(frame)
+		if err != nil {
+			t.Fatalf("Encode iter %d: %v", i, err)
+		}
+		if _, err := c.Decode(enc); err != nil {
+			t.Fatalf("Decode iter %d: %v", i, err)
+		}
+	}
+}

--- a/internal/voip/media/mlow_codec_real.go
+++ b/internal/voip/media/mlow_codec_real.go
@@ -51,6 +51,14 @@ const (
 
 var globalInitOnce sync.Once
 
+// codecCallMu serializes ALL calls into the opus_mlow C library. The bundled
+// MLow/SMPL build is not thread-safe: concurrent Encode/Decode on a codec
+// corrupts native state and crashes the process ("fatal error: semasleep on
+// Darwin signal stack"). In a live call Encode (uplink) and Decode (downlink)
+// run on different goroutines, so every C entry point must hold this lock.
+// Each call is sub-millisecond, so serializing them has no practical cost.
+var codecCallMu sync.Mutex
+
 type mlowCodec struct {
 	encoder unsafe.Pointer
 	decoder unsafe.Pointer
@@ -63,6 +71,8 @@ func NewMLowCodec(opts CodecOptions) (Codec, error) {
 	if opts.Complexity == 0 {
 		opts.Complexity = DefaultCodecOptions.Complexity
 	}
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	globalInitOnce.Do(func() { C.opus_global_create() })
 
 	c := &mlowCodec{}
@@ -97,6 +107,8 @@ func (c *mlowCodec) Encode(pcm []float32) ([]byte, error) {
 	if len(pcm) == 0 {
 		return nil, nil
 	}
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	in := make([]C.int16_t, len(pcm))
 	for i, s := range pcm {
 		if s > 1 {
@@ -119,6 +131,8 @@ func (c *mlowCodec) Encode(pcm []float32) ([]byte, error) {
 }
 
 func (c *mlowCodec) Decode(frame []byte) ([]float32, error) {
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	out := make([]C.int16_t, mlowMaxOut)
 	var n C.int
 	if frame == nil {
@@ -141,6 +155,8 @@ func (c *mlowCodec) FrameSize() int  { return mlowFrameSize }
 func (c *mlowCodec) SampleRate() int { return mlowSampleRate }
 
 func (c *mlowCodec) Close() {
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	if c.decoder != nil {
 		C.opus_decoder_destroy(c.decoder)
 		c.decoder = nil
@@ -159,6 +175,8 @@ type opusGeneric struct {
 }
 
 func NewOpusCodec(sampleRate, frameSize int) (Codec, error) {
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	globalInitOnce.Do(func() { C.opus_global_create() })
 	c := &opusGeneric{sampleRate: sampleRate, frameSize: frameSize}
 
@@ -182,6 +200,8 @@ func (c *opusGeneric) Encode(pcm []float32) ([]byte, error) {
 	if len(pcm) == 0 {
 		return nil, nil
 	}
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	in := make([]C.int16_t, len(pcm))
 	for i, s := range pcm {
 		if s > 1 {
@@ -204,6 +224,8 @@ func (c *opusGeneric) Encode(pcm []float32) ([]byte, error) {
 }
 
 func (c *opusGeneric) Decode(frame []byte) ([]float32, error) {
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	maxOut := c.sampleRate / 1000 * 120
 	out := make([]C.int16_t, maxOut)
 	var n C.int
@@ -227,6 +249,8 @@ func (c *opusGeneric) FrameSize() int  { return c.frameSize }
 func (c *opusGeneric) SampleRate() int { return c.sampleRate }
 
 func (c *opusGeneric) Close() {
+	codecCallMu.Lock()
+	defer codecCallMu.Unlock()
 	if c.decoder != nil {
 		C.opus_decoder_destroy(c.decoder)
 		c.decoder = nil


### PR DESCRIPTION
## Problem
The bundled `opus_mlow` (MLow/SMPL) native library is **not thread-safe**. Calling `Encode` and `Decode` on the same codec from different goroutines corrupts native state and crashes the **entire process**:

```
fatal error: semasleep on Darwin signal stack
```

In a live call this triggers reliably: the uplink encodes (browser → WhatsApp) while the downlink decodes (WhatsApp → browser) on a different goroutine, the moment audio flows in both directions.

## Fix
Guard every C entry point (`Encode` / `Decode` / `Close` and both constructors) with a package-level mutex in `mlow_codec_real.go`. Codec calls are sub-millisecond and happen every 20–60 ms, so serializing them has no practical cost.

## Tests
Adds `codec_concurrency_test.go` (build tag `mlow`):
- reproduces the crash with concurrent `Encode`/`Decode` (crashed reliably before, passes 10× now, incl. `-race`);
- covers the Opus 48 kHz path, which had no test before.

Note: these tests only build under `-tags mlow`, so CI (which builds without the tag) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)