### PR TITLE
feat(config): configure server/client ports via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# WaCalls server (Go)
+PORT=8080
+DB_PATH=wacalls.db
+STATIC_DIR=client/dist
+DEBUG=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Local environment config (use .env.example as the template)
+.env
+.env.local
+.env.*.local
+!.env.example
+
 /docs
 /wacalls-server.exe
 /wacalls.exe

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Vite dev server port
+PORT=5173
+# Backend the dev server proxies /api to (the Go server PORT)
+API_PORT=8080
+# Or set a full URL to override: VITE_API_TARGET=http://localhost:8080

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,16 +1,23 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "node:url";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      "/api": { target: "http://localhost:3001", changeOrigin: true, ws: false },
+export default defineConfig(({ mode }) => {
+  // Load .env (all keys, not just VITE_*) for dev-server config.
+  const env = loadEnv(mode, process.cwd(), "");
+  const port = Number(env.PORT ?? 5173);
+  const apiTarget = env.VITE_API_TARGET || `http://localhost:${env.API_PORT ?? 8080}`;
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
     },
-  },
+    server: {
+      port,
+      proxy: {
+        "/api": { target: apiTarget, changeOrigin: true, ws: false },
+      },
+    },
+  };
 });

--- a/cmd/server/env.go
+++ b/cmd/server/env.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// loadDotEnv loads KEY=VALUE pairs from the given file into the process
+// environment. Variables already present in the real environment are NOT
+// overridden, so the shell takes precedence over the file. A missing file is
+// not an error.
+func loadDotEnv(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		if len(val) >= 2 {
+			if (val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+		if key == "" {
+			continue
+		}
+		if _, exists := os.LookupEnv(key); !exists {
+			_ = os.Setenv(key, val)
+		}
+	}
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func getenvBool(key string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return def
+	}
+}
+
+// listenAddr builds the HTTP listen address from PORT, e.g. "8080" -> ":8080".
+func listenAddr() string {
+	return ":" + strings.TrimPrefix(getenv("PORT", "8080"), ":")
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,10 +13,13 @@ import (
 )
 
 func main() {
-	addr := flag.String("addr", ":8080", "HTTP listen address")
-	dbPath := flag.String("db", "wacalls.db", "SQLite session database path")
-	staticDir := flag.String("static", "client/dist", "static client directory (optional)")
-	debug := flag.Bool("debug", false, "verbose logging")
+	loadDotEnv(".env")
+
+	// Defaults come from .env / the environment; explicit flags override them.
+	addr := flag.String("addr", listenAddr(), "HTTP listen address (or set PORT)")
+	dbPath := flag.String("db", getenv("DB_PATH", "wacalls.db"), "SQLite session database path")
+	staticDir := flag.String("static", getenv("STATIC_DIR", "client/dist"), "static client directory (optional)")
+	debug := flag.Bool("debug", getenvBool("DEBUG", false), "verbose logging")
 	flag.Parse()
 
 	level := slog.LevelInfo


### PR DESCRIPTION
## What
Make the listen port (and a few other settings) configurable via `.env`, on both the Go server and the Vite client.

### Server (`cmd/server`)
- New `env.go`: a tiny `.env` loader (no new dependency).
- `main.go` reads `PORT`, `DB_PATH`, `STATIC_DIR`, `DEBUG` as flag defaults. Explicit flags still override → precedence is **flag > env var > .env > default**.

### Client (`client/vite.config.ts`)
- Reads `PORT` (dev-server port) and `API_PORT` / `VITE_API_TARGET` (the `/api` proxy target) via `loadEnv`.
- Also fixes the dev proxy, which previously pointed at a port that didn't match the server.

### Templates & ignore
- Adds `.env.example` and `client/.env.example`.
- `.gitignore` ignores the real `.env` files but keeps the examples.

## Usage
```bash
cp .env.example .env                 # server
cp client/.env.example client/.env   # client (dev)
```
Change `PORT` (root) and `API_PORT` (client) together so the dev proxy keeps matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)