### PR TITLE
fix(call): end the call cleanly when the offer is rejected

### DIFF
--- a/cmd/server/broker.go
+++ b/cmd/server/broker.go
@@ -51,6 +51,7 @@ type Broker struct {
 	mu      sync.RWMutex
 	subs    map[*subscriber]struct{}
 	calls   map[string]*CallRecord
+	ended   map[string]struct{}
 	history []CallRecord
 
 	SnapshotFn func() []any
@@ -60,6 +61,7 @@ func NewBroker() *Broker {
 	return &Broker{
 		subs:  map[*subscriber]struct{}{},
 		calls: map[string]*CallRecord{},
+		ended: map[string]struct{}{},
 	}
 }
 
@@ -110,6 +112,12 @@ func (b *Broker) emitSessionQR(sessionID, qr string) {
 
 func (b *Broker) upsertCall(r CallRecord) {
 	b.mu.Lock()
+	if _, done := b.ended[r.CallID]; done {
+		// A late upsert must not resurrect a call that already ended (e.g. an
+		// offer rejected before the HTTP handler recorded it as ringing).
+		b.mu.Unlock()
+		return
+	}
 	cp := r
 	b.calls[r.CallID] = &cp
 	b.mu.Unlock()
@@ -147,6 +155,7 @@ func (b *Broker) setOwner(id, owner string) bool {
 
 func (b *Broker) endCall(id, reason string) {
 	b.mu.Lock()
+	b.ended[id] = struct{}{}
 	c, ok := b.calls[id]
 	if !ok {
 		b.mu.Unlock()

--- a/internal/voip/call/callmanager.go
+++ b/internal/voip/call/callmanager.go
@@ -204,6 +204,26 @@ func (m *CallManager) EndCall(ctx context.Context, reason core.EndCallReason) er
 	return nil
 }
 
+// abortCall ends the current call locally (no terminate stanza is sent — the
+// call never connected) and drives the normal end-of-call notifications so the
+// UI clears. Used when call setup fails, e.g. the offer is rejected by WhatsApp.
+func (m *CallManager) abortCall(reason core.EndCallReason) {
+	m.mu.Lock()
+	call := m.currentCall
+	if call == nil || call.IsEnded() {
+		m.mu.Unlock()
+		return
+	}
+	_ = call.ApplyTransition(Transition{Type: TransitionTerminated, Reason: reason})
+	ended := call
+	m.emitState()
+	m.mu.Unlock()
+	if m.OnEnded != nil {
+		m.OnEnded(ended)
+	}
+	m.cleanupMedia()
+}
+
 func (m *CallManager) ownCredJid() string {
 	lid := m.sock.OwnLID()
 	if !lid.IsEmpty() {

--- a/internal/voip/call/callmanager_signaling.go
+++ b/internal/voip/call/callmanager_signaling.go
@@ -176,7 +176,9 @@ func (m *CallManager) HandleCallAck(ctx context.Context, node *waBinary.Node) {
 		return
 	}
 	if e := wanode.AttrString(node.Attrs, "error"); e != "" {
-		m.log.Error("offer ack error", "error", e)
+		m.log.Error("offer rejected by server", "error", e,
+			"hint", "439/463 usually means a missing/invalid privacy (tc) token or a rate limit")
+		m.abortCall(core.EndCallReasonFailed)
 		return
 	}
 	parsed := signaling.ParseRelayFromAck(node)


### PR DESCRIPTION
## Problem
When WhatsApp rejected an outgoing offer (e.g. `ack error 439`), `HandleCallAck` only logged the error and returned. The call was never marked ended, so the UI kept showing **"ringing" forever**.

## Fix
- `CallManager.abortCall`: ends the current call locally (no terminate stanza — it never connected) and drives the normal end-of-call notifications, so the frontend clears. `HandleCallAck` calls it on an ack error and logs a clearer message.
- Broker: a small `ended` guard so a late `upsertCall` (the HTTP handler recording the call as "ringing") can't **resurrect** a call that the rejection already ended — this was a real race because the ack can arrive before the handler finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)