### PR TITLE
fix(call): count call duration from answer time, not dial time

### DIFF
--- a/client/src/components/domain/call/CallCard.tsx
+++ b/client/src/components/domain/call/CallCard.tsx
@@ -76,7 +76,7 @@ export const CallCard = ({ call }: { call: CallSummary }) => {
           <div className="min-w-0">
             <p className="truncate font-medium">{call.peer}</p>
             <Badge variant={statusVariant[call.status]} className="mt-1">
-              {formatCallDuration(call.startedAt, call.status)}
+              {formatCallDuration(call)}
             </Badge>
           </div>
           <Tooltip>

--- a/client/src/components/domain/call/OtherCallsList.tsx
+++ b/client/src/components/domain/call/OtherCallsList.tsx
@@ -20,7 +20,7 @@ export const OtherCallsList = ({ calls }: { calls: CallSummary[] }) => {
                 <p className="truncate text-sm font-medium">{c.peer}</p>
                 <p className="text-xs text-muted-foreground">{c.direction}</p>
               </div>
-              <Badge variant="muted">{formatCallDuration(c.startedAt, c.status)}</Badge>
+              <Badge variant="muted">{formatCallDuration(c)}</Badge>
             </CardContent>
           </Card>
         ))}

--- a/client/src/lib/event-stream.ts
+++ b/client/src/lib/event-stream.ts
@@ -8,6 +8,7 @@ type CallListRow = {
   direction: "outbound" | "inbound";
   peer: string;
   startedAt: number;
+  connectedAt?: number | null;
   status: CallStatus;
   endedAt?: number;
   endReason?: string;
@@ -18,7 +19,7 @@ export type BrokerEvent =
   | { type: "session-qr"; sessionId: string; qr: string }
   | { type: "auth-state"; sessionId: string; paired: boolean; state: SessionState; qr?: string }
   | { type: "call-list"; calls: CallListRow[] }
-  | { type: "call-status"; sessionId: string; id: string; owner: string | null; status: CallStatus; peer: string; startedAt: number }
+  | { type: "call-status"; sessionId: string; id: string; owner: string | null; status: CallStatus; peer: string; startedAt: number; connectedAt?: number | null }
   | { type: "call-ended"; sessionId: string; id: string; owner: string | null; reason: string; endedAt: number }
   | { type: "incoming"; sessionId: string; id: string; peer: string; offeredAt: number }
   | { type: "incoming-claimed"; sessionId: string; id: string; owner: string };

--- a/client/src/stores/calls.ts
+++ b/client/src/stores/calls.ts
@@ -28,7 +28,7 @@ export const ensureCallsWired = (): void => {
       useCalls.setState((s) => ({
         calls: s.calls.map((c) =>
           c.callId === ev.id
-            ? { ...c, sessionId: ev.sessionId, status: ev.status, peer: ev.peer, startedAt: ev.startedAt }
+            ? { ...c, sessionId: ev.sessionId, status: ev.status, peer: ev.peer, startedAt: ev.startedAt, connectedAt: ev.connectedAt ?? c.connectedAt }
             : c,
         ),
       }));

--- a/client/src/types/call.ts
+++ b/client/src/types/call.ts
@@ -7,6 +7,7 @@ export type CallSummary = {
   direction: "outbound" | "inbound";
   peer: string;
   startedAt: number;
+  connectedAt?: number | null;
   status: CallStatus;
 };
 

--- a/client/src/utils/format.ts
+++ b/client/src/utils/format.ts
@@ -1,7 +1,9 @@
-import type { CallStatus } from "@/types/call";
+import type { CallSummary } from "@/types/call";
 
-export const formatCallDuration = (startedAt: number, status: CallStatus): string => {
-  if (status !== "connected") return status;
-  const s = Math.floor((Date.now() - startedAt) / 1000);
+export const formatCallDuration = (call: CallSummary): string => {
+  if (call.status !== "connected") return call.status;
+  // Count from when the call was answered (connectedAt), not the dial time.
+  const since = call.connectedAt ?? call.startedAt;
+  const s = Math.max(0, Math.floor((Date.now() - since) / 1000));
   return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
 };

--- a/cmd/server/broker.go
+++ b/cmd/server/broker.go
@@ -17,15 +17,16 @@ const (
 )
 
 type CallRecord struct {
-	SessionID string     `json:"sessionId"`
-	CallID    string     `json:"callId"`
-	Owner     *string    `json:"owner"`
-	Direction string     `json:"direction"`
-	Peer      string     `json:"peer"`
-	StartedAt int64      `json:"startedAt"`
-	Status    CallStatus `json:"status"`
-	EndedAt   *int64     `json:"endedAt,omitempty"`
-	EndReason string     `json:"endReason,omitempty"`
+	SessionID   string     `json:"sessionId"`
+	CallID      string     `json:"callId"`
+	Owner       *string    `json:"owner"`
+	Direction   string     `json:"direction"`
+	Peer        string     `json:"peer"`
+	StartedAt   int64      `json:"startedAt"`
+	ConnectedAt *int64     `json:"connectedAt,omitempty"`
+	Status      CallStatus `json:"status"`
+	EndedAt     *int64     `json:"endedAt,omitempty"`
+	EndReason   string     `json:"endReason,omitempty"`
 }
 
 type AuthSnapshot struct {
@@ -124,7 +125,7 @@ func (b *Broker) upsertCall(r CallRecord) {
 	b.broadcastCallList()
 	b.broadcast(map[string]any{
 		"type": "call-status", "sessionId": r.SessionID, "id": r.CallID, "owner": r.Owner,
-		"status": r.Status, "peer": r.Peer, "startedAt": r.StartedAt,
+		"status": r.Status, "peer": r.Peer, "startedAt": r.StartedAt, "connectedAt": r.ConnectedAt,
 	})
 }
 

--- a/cmd/server/broker.go
+++ b/cmd/server/broker.go
@@ -51,6 +51,7 @@ type Broker struct {
 	mu      sync.RWMutex
 	subs    map[*subscriber]struct{}
 	calls   map[string]*CallRecord
+	ended   map[string]struct{}
 	history []CallRecord
 
 	SnapshotFn func() []any
@@ -60,6 +61,7 @@ func NewBroker() *Broker {
 	return &Broker{
 		subs:  map[*subscriber]struct{}{},
 		calls: map[string]*CallRecord{},
+		ended: map[string]struct{}{},
 	}
 }
 
@@ -110,6 +112,12 @@ func (b *Broker) emitSessionQR(sessionID, qr string) {
 
 func (b *Broker) upsertCall(r CallRecord) {
 	b.mu.Lock()
+	if _, done := b.ended[r.CallID]; done {
+		// A late upsert must not resurrect a call that already ended (e.g. an
+		// offer rejected before the HTTP handler recorded it as ringing).
+		b.mu.Unlock()
+		return
+	}
 	cp := r
 	b.calls[r.CallID] = &cp
 	b.mu.Unlock()
@@ -147,6 +155,7 @@ func (b *Broker) setOwner(id, owner string) bool {
 
 func (b *Broker) endCall(id, reason string) {
 	b.mu.Lock()
+	b.ended[id] = struct{}{}
 	c, ok := b.calls[id]
 	if !ok {
 		b.mu.Unlock()

--- a/cmd/server/session.go
+++ b/cmd/server/session.go
@@ -69,6 +69,12 @@ func (s *Session) wireCallManager() {
 			rec.Owner = existing.Owner
 			rec.StartedAt = existing.StartedAt
 		}
+		// ConnectedAt is set once, when the call is answered (state ACTIVE);
+		// the UI measures call duration from this, not from the dial time.
+		if c.StateData.ConnectedAt != nil {
+			ms := c.StateData.ConnectedAt.UnixMilli()
+			rec.ConnectedAt = &ms
+		}
 		if c.IsEnded() {
 			s.mgr.broker.endCall(c.CallID, string(c.StateData.EndReason))
 			return

--- a/internal/voip/call/callmanager.go
+++ b/internal/voip/call/callmanager.go
@@ -204,6 +204,26 @@ func (m *CallManager) EndCall(ctx context.Context, reason core.EndCallReason) er
 	return nil
 }
 
+// abortCall ends the current call locally (no terminate stanza is sent — the
+// call never connected) and drives the normal end-of-call notifications so the
+// UI clears. Used when call setup fails, e.g. the offer is rejected by WhatsApp.
+func (m *CallManager) abortCall(reason core.EndCallReason) {
+	m.mu.Lock()
+	call := m.currentCall
+	if call == nil || call.IsEnded() {
+		m.mu.Unlock()
+		return
+	}
+	_ = call.ApplyTransition(Transition{Type: TransitionTerminated, Reason: reason})
+	ended := call
+	m.emitState()
+	m.mu.Unlock()
+	if m.OnEnded != nil {
+		m.OnEnded(ended)
+	}
+	m.cleanupMedia()
+}
+
 func (m *CallManager) ownCredJid() string {
 	lid := m.sock.OwnLID()
 	if !lid.IsEmpty() {

--- a/internal/voip/call/callmanager_signaling.go
+++ b/internal/voip/call/callmanager_signaling.go
@@ -176,7 +176,9 @@ func (m *CallManager) HandleCallAck(ctx context.Context, node *waBinary.Node) {
 		return
 	}
 	if e := wanode.AttrString(node.Attrs, "error"); e != "" {
-		m.log.Error("offer ack error", "error", e)
+		m.log.Error("offer rejected by server", "error", e,
+			"hint", "439/463 usually means a missing/invalid privacy (tc) token or a rate limit")
+		m.abortCall(core.EndCallReasonFailed)
 		return
 	}
 	parsed := signaling.ParseRelayFromAck(node)


### PR DESCRIPTION
## Problem
The call timer started counting at **dial** time: `formatCallDuration` measured elapsed time from `startedAt`, which the broker sets when the call record is created (ringing) and never updates. Once a call connected, its duration therefore included the whole ringing period.

## Fix
Carry a `connectedAt` timestamp — set only when the call transitions to **ACTIVE** (answered) — from the backend (`CallStateData.ConnectedAt`) through the broker, the SSE `call-status` event and the client store, and measure the duration from `connectedAt` instead of `startedAt`.

## ⚠️ Stacked on #10
This branch is stacked on **#10** (`fix/end-rejected-call`) because both touch `broker.go`. Please merge **#10 first** — afterwards GitHub will recompute this PR's diff to show only the timer changes. Until then the diff also shows #10's commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)