### PR TITLE
feat: multiple concurrent calls per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ that is optional — without it the server runs in **signaling-only** mode (pair
 call setup work; no live audio).
 
 Multiple WhatsApp accounts can be paired and operated side by side, each with its own
-pairing QR, connection status, call manager, and history.
+pairing QR, connection status, and history. A single account can also run **several
+concurrent 1:1 calls** at once — one per browser operator — routed independently by call ID.
 
 > **Status:** stable. Outgoing and incoming 1:1 calls reach `ACTIVE` with bidirectional
-> audio. Sessions persist in `wacalls.db` (pure-Go SQLite).
+> audio, and a single account can hold several of them concurrently. Sessions persist in
+> `wacalls.db` (pure-Go SQLite).
 
 ---
 
@@ -187,6 +189,7 @@ go run ./cmd/server -static client/dist -addr :8080
 | `-db` | `wacalls.db` | SQLite session database path |
 | `-static` | `client/dist` | Static client directory (optional) |
 | `-debug` | `false` | Verbose logging (includes whatsmeow's internal log) |
+| `-max-calls-per-session` | `8` | Max concurrent calls per session (`0` = unlimited) |
 
 ---
 

--- a/cmd/server/bridge.go
+++ b/cmd/server/bridge.go
@@ -13,7 +13,8 @@ type Bridge struct {
 	localTrack *webrtc.TrackLocalStaticSample
 	log        *slog.Logger
 
-	OnBrowserRTP func(payload []byte)
+	OnBrowserRTP  func(payload []byte)
+	OnTerminalICE func()
 }
 
 func NewBridge(offerSDP string, log *slog.Logger) (*Bridge, string, error) {
@@ -56,6 +57,11 @@ func NewBridge(offerSDP string, log *slog.Logger) (*Bridge, string, error) {
 
 	pc.OnICEConnectionStateChange(func(s webrtc.ICEConnectionState) {
 		log.Debug("browser ice state", "state", s.String())
+		if s == webrtc.ICEConnectionStateFailed || s == webrtc.ICEConnectionStateClosed {
+			if br.OnTerminalICE != nil {
+				br.OnTerminalICE()
+			}
+		}
 	})
 
 	if err := pc.SetRemoteDescription(webrtc.SessionDescription{Type: webrtc.SDPTypeOffer, SDP: offerSDP}); err != nil {

--- a/cmd/server/broker.go
+++ b/cmd/server/broker.go
@@ -145,6 +145,20 @@ func (b *Broker) setOwner(id, owner string) bool {
 	return true
 }
 
+func (b *Broker) ownerActiveCall(owner string) string {
+	if owner == "" {
+		return ""
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for id, c := range b.calls {
+		if c.Owner != nil && *c.Owner == owner && c.Status != StatusEnded {
+			return id
+		}
+	}
+	return ""
+}
+
 func (b *Broker) endCall(id, reason string) {
 	b.mu.Lock()
 	c, ok := b.calls[id]

--- a/cmd/server/broker_test.go
+++ b/cmd/server/broker_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func ownerPtr(s string) *string { return &s }
+
+func TestOwnerActiveCall(t *testing.T) {
+	b := NewBroker()
+	b.upsertCall(CallRecord{SessionID: "s1", CallID: "c1", Owner: ownerPtr("op-A"), Status: StatusConnected})
+	b.upsertCall(CallRecord{SessionID: "s1", CallID: "c2", Owner: ownerPtr("op-B"), Status: StatusRinging})
+
+	if got := b.ownerActiveCall("op-A"); got != "c1" {
+		t.Fatalf("op-A should own c1, got %q", got)
+	}
+	if got := b.ownerActiveCall("op-C"); got != "" {
+		t.Fatalf("op-C owns nothing, got %q", got)
+	}
+	if got := b.ownerActiveCall(""); got != "" {
+		t.Fatalf("empty owner must return empty, got %q", got)
+	}
+
+	b.endCall("c1", "done")
+	if got := b.ownerActiveCall("op-A"); got != "" {
+		t.Fatalf("op-A's call ended, expected empty, got %q", got)
+	}
+}

--- a/cmd/server/callregistry.go
+++ b/cmd/server/callregistry.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"sync"
+
+	"wacalls/internal/voip/call"
+	"wacalls/internal/voip/media"
+)
+
+type activeCall struct {
+	cm          *call.CallManager
+	bridge      *Bridge
+	browserOpus media.Codec
+}
+
+type callRegistry struct {
+	mu    sync.Mutex
+	calls map[string]*activeCall
+}
+
+func newCallRegistry() *callRegistry {
+	return &callRegistry{calls: map[string]*activeCall{}}
+}
+
+func (r *callRegistry) add(callID string, ac *activeCall) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls[callID] = ac
+}
+
+func (r *callRegistry) get(callID string) (*activeCall, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ac, ok := r.calls[callID]
+	return ac, ok
+}
+
+func (r *callRegistry) remove(callID string) (*activeCall, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ac, ok := r.calls[callID]
+	if !ok {
+		return nil, false
+	}
+	delete(r.calls, callID)
+	return ac, true
+}
+
+func (r *callRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func (r *callRegistry) setBridge(callID string, b *Bridge, oc media.Codec) (*Bridge, media.Codec, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ac, ok := r.calls[callID]
+	if !ok {
+		return nil, nil, false
+	}
+	oldB, oldOC := ac.bridge, ac.browserOpus
+	ac.bridge, ac.browserOpus = b, oc
+	return oldB, oldOC, true
+}
+
+func (r *callRegistry) drain() []*activeCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*activeCall, 0, len(r.calls))
+	for _, ac := range r.calls {
+		out = append(out, ac)
+	}
+	r.calls = map[string]*activeCall{}
+	return out
+}

--- a/cmd/server/callregistry_test.go
+++ b/cmd/server/callregistry_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestCallRegistryAddGetRemove(t *testing.T) {
+	r := newCallRegistry()
+	if r.count() != 0 {
+		t.Fatalf("new registry must be empty, got %d", r.count())
+	}
+
+	a := &activeCall{}
+	r.add("c1", a)
+	r.add("c2", &activeCall{})
+	if r.count() != 2 {
+		t.Fatalf("expected 2, got %d", r.count())
+	}
+
+	got, ok := r.get("c1")
+	if !ok || got != a {
+		t.Fatalf("get c1 mismatch: ok=%v", ok)
+	}
+
+	removed, ok := r.remove("c1")
+	if !ok || removed != a {
+		t.Fatalf("remove c1 should return it: ok=%v", ok)
+	}
+	if _, ok := r.get("c1"); ok {
+		t.Fatal("c1 must be gone after remove")
+	}
+	if _, ok := r.remove("c1"); ok {
+		t.Fatal("removing twice must report not-found (idempotent)")
+	}
+	if r.count() != 1 {
+		t.Fatalf("expected 1 left, got %d", r.count())
+	}
+}
+
+func TestCallRegistryDrain(t *testing.T) {
+	r := newCallRegistry()
+	r.add("c1", &activeCall{})
+	r.add("c2", &activeCall{})
+	all := r.drain()
+	if len(all) != 2 {
+		t.Fatalf("drain should return 2, got %d", len(all))
+	}
+	if r.count() != 0 {
+		t.Fatalf("registry must be empty after drain, got %d", r.count())
+	}
+}
+
+func TestCallRegistrySetBridgeMissing(t *testing.T) {
+	r := newCallRegistry()
+	_, _, found := r.setBridge("nope", nil, nil)
+	if found {
+		t.Fatal("setBridge on missing call must report not-found")
+	}
+}

--- a/cmd/server/callrouting.go
+++ b/cmd/server/callrouting.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"wacalls/internal/voip/signaling"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+)
+
+func callIDFromNode(node *waBinary.Node) string {
+	info := signaling.ExtractNodeInfo(node)
+	if info == nil {
+		return ""
+	}
+	return info.CallID
+}

--- a/cmd/server/callrouting_test.go
+++ b/cmd/server/callrouting_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+)
+
+func TestCallIDFromNode(t *testing.T) {
+	node := &waBinary.Node{
+		Tag: "call",
+		Content: []waBinary.Node{{
+			Tag:   "offer",
+			Attrs: waBinary.Attrs{"call-id": "ABC123"},
+		}},
+	}
+	if got := callIDFromNode(node); got != "ABC123" {
+		t.Fatalf("expected ABC123, got %q", got)
+	}
+
+	empty := &waBinary.Node{Tag: "call"}
+	if got := callIDFromNode(empty); got != "" {
+		t.Fatalf("node with no children must yield empty, got %q", got)
+	}
+}

--- a/cmd/server/httpapi.go
+++ b/cmd/server/httpapi.go
@@ -172,14 +172,22 @@ func (s *server) doStartCall(sess *Session, w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "phone required"})
 		return
 	}
+	owner := clientID(r)
+	if other := s.broker.ownerActiveCall(owner); other != "" {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "operator already on a call"})
+		return
+	}
+	if max := s.sessions.maxCalls; max > 0 && sess.reg.count() >= max {
+		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "max concurrent calls"})
+		return
+	}
 	peer := types.NewJID(normalizePhone(body.Phone), types.DefaultUserServer)
 
-	callID, err := sess.cm.StartCall(r.Context(), peer, false)
+	callID, err := sess.startOutgoing(r.Context(), peer, false)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	owner := clientID(r)
 	s.broker.upsertCall(CallRecord{
 		SessionID: sess.id, CallID: callID, Owner: &owner, Direction: "outbound", Peer: peer.String(),
 		StartedAt: time.Now().UnixMilli(), Status: StatusRinging,
@@ -188,6 +196,12 @@ func (s *server) doStartCall(sess *Session, w http.ResponseWriter, r *http.Reque
 }
 
 func (s *server) doWebRTC(sess *Session, w http.ResponseWriter, r *http.Request) {
+	callID := r.PathValue("id")
+	ac, ok := sess.reg.get(callID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no such call"})
+		return
+	}
 	var body struct {
 		SDPOffer string `json:"sdp_offer"`
 	}
@@ -214,21 +228,33 @@ func (s *server) doWebRTC(sess *Session, w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			return
 		}
-		sess.cm.FeedCapturedPCM(media.Downsample48to16(pcm48))
+		ac.cm.FeedCapturedPCM(media.Downsample48to16(pcm48))
 	}
-	sess.setBridge(bridge, browserOpus)
+	bridge.OnTerminalICE = func() {
+		go sess.terminateCall(callID, core.EndCallReasonUserEnded)
+	}
+	sess.setBridge(callID, bridge, browserOpus)
 	writeJSON(w, http.StatusOK, map[string]string{"sdp_answer": answer})
 }
 
 func (s *server) doAccept(sess *Session, w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	ac, ok := sess.reg.get(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no such call"})
+		return
+	}
 	owner := clientID(r)
+	if other := s.broker.ownerActiveCall(owner); other != "" && other != id {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "operator already on a call"})
+		return
+	}
 	if !s.broker.setOwner(id, owner) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "claimed by another client"})
 		return
 	}
 	s.broker.emitIncomingClaimed(sess.id, id, owner)
-	if err := sess.cm.AcceptCall(r.Context(), id); err != nil {
+	if err := ac.cm.AcceptCall(r.Context(), id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -236,15 +262,22 @@ func (s *server) doAccept(sess *Session, w http.ResponseWriter, r *http.Request)
 }
 
 func (s *server) doReject(sess *Session, w http.ResponseWriter, r *http.Request) {
-	_ = sess.cm.RejectCall(r.Context(), r.PathValue("id"), core.EndCallReasonDeclined)
+	id := r.PathValue("id")
+	if ac, ok := sess.reg.get(id); ok {
+		_ = ac.cm.RejectCall(r.Context(), id, core.EndCallReasonDeclined)
+	}
+	sess.removeCall(id)
+	s.broker.endCall(id, string(core.EndCallReasonDeclined))
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func (s *server) doEndCall(sess *Session, w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	_ = sess.cm.EndCall(r.Context(), core.EndCallReasonUserEnded)
+	if ac, ok := sess.reg.get(id); ok {
+		_ = ac.cm.EndCall(r.Context(), core.EndCallReasonUserEnded)
+	}
+	sess.removeCall(id)
 	s.broker.endCall(id, string(core.EndCallReasonUserEnded))
-	sess.closeBridge()
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ func main() {
 	dbPath := flag.String("db", "wacalls.db", "SQLite session database path")
 	staticDir := flag.String("static", "client/dist", "static client directory (optional)")
 	debug := flag.Bool("debug", false, "verbose logging")
+	maxCalls := flag.Int("max-calls-per-session", 8, "max concurrent calls per session (0 = unlimited)")
 	flag.Parse()
 
 	level := slog.LevelInfo
@@ -29,7 +30,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	srv, err := newServer(ctx, *dbPath, *staticDir, log)
+	srv, err := newServer(ctx, *dbPath, *staticDir, *maxCalls, log)
 	if err != nil {
 		log.Error("startup failed", "err", err)
 		os.Exit(1)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -27,7 +27,7 @@ func openDB(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
-func newServer(ctx context.Context, dbPath, staticDir string, log *slog.Logger) (*server, error) {
+func newServer(ctx context.Context, dbPath, staticDir string, maxCalls int, log *slog.Logger) (*server, error) {
 	db, err := openDB(dbPath)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func newServer(ctx context.Context, dbPath, staticDir string, log *slog.Logger) 
 	}
 
 	broker := NewBroker()
-	mgr := newSessionManager(ctx, container, broker, store, waLogger, log)
+	mgr := newSessionManager(ctx, container, broker, store, waLogger, log, maxCalls)
 	broker.SnapshotFn = mgr.snapshotEvents
 
 	return &server{broker: broker, sessions: mgr, log: log, staticDir: staticDir}, nil

--- a/cmd/server/session.go
+++ b/cmd/server/session.go
@@ -10,10 +10,14 @@ import (
 	"wacalls/internal/voip/call"
 	"wacalls/internal/voip/core"
 	"wacalls/internal/voip/media"
+	"wacalls/internal/voip/signaling"
+	"wacalls/internal/voip/wanode"
 	"wacalls/internal/wa"
 
 	"github.com/mdp/qrterminal/v3"
 	"go.mau.fi/whatsmeow"
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
 
@@ -24,12 +28,10 @@ type Session struct {
 	log  *slog.Logger
 
 	client *whatsmeow.Client
-	cm     *call.CallManager
+	reg    *callRegistry
 
-	mu          sync.Mutex
-	bridge      *Bridge
-	browserOpus media.Codec
-	auth        AuthSnapshot
+	mu   sync.Mutex
+	auth AuthSnapshot
 }
 
 func newSession(mgr *SessionManager, id, name string, client *whatsmeow.Client) *Session {
@@ -40,22 +42,33 @@ func newSession(mgr *SessionManager, id, name string, client *whatsmeow.Client) 
 		log:    mgr.log.With("session", id),
 		client: client,
 		auth:   AuthSnapshot{State: "connecting"},
+		reg:    newCallRegistry(),
 	}
-	s.cm = call.NewCallManager(wa.NewSocket(client), s.log)
-	s.wireCallManager()
 	client.AddEventHandler(s.handleEvent)
 	return s
 }
 
-func (s *Session) wireCallManager() {
-	s.cm.OnIncoming = func(c *call.CallInfo) {
+func (s *Session) createCall(callID string) *call.CallManager {
+	cm := call.NewCallManager(wa.NewSocket(s.client), s.log)
+	s.wireCall(cm, callID)
+	s.reg.add(callID, &activeCall{cm: cm})
+	return cm
+}
+
+func (s *Session) wireCall(cm *call.CallManager, callID string) {
+	cm.OnIncoming = func(c *call.CallInfo) {
 		s.mgr.broker.upsertCall(CallRecord{
 			SessionID: s.id, CallID: c.CallID, Direction: "inbound", Peer: c.PeerJid,
 			StartedAt: time.Now().UnixMilli(), Status: StatusRinging,
 		})
 		s.mgr.broker.emitIncoming(s.id, c.CallID, c.PeerJid)
 	}
-	s.cm.OnStateChange = func(c *call.CallInfo) {
+	cm.OnStateChange = func(c *call.CallInfo) {
+		if c.IsEnded() {
+			s.removeCall(c.CallID)
+			s.mgr.broker.endCall(c.CallID, string(c.StateData.EndReason))
+			return
+		}
 		dir := "outbound"
 		if c.Direction == core.CallDirectionIncoming {
 			dir = "inbound"
@@ -69,31 +82,70 @@ func (s *Session) wireCallManager() {
 			rec.Owner = existing.Owner
 			rec.StartedAt = existing.StartedAt
 		}
-		if c.IsEnded() {
-			s.mgr.broker.endCall(c.CallID, string(c.StateData.EndReason))
-			return
-		}
 		s.mgr.broker.upsertCall(rec)
 	}
-	s.cm.OnEnded = func(c *call.CallInfo) {
+	cm.OnEnded = func(c *call.CallInfo) {
+		s.removeCall(c.CallID)
 		s.mgr.broker.endCall(c.CallID, string(c.StateData.EndReason))
-		s.closeBridge()
 	}
-	s.cm.OnPeerAudio = func(pcm16 []float32) {
-		s.mu.Lock()
-		br := s.bridge
-		oc := s.browserOpus
-		s.mu.Unlock()
-		if br == nil || oc == nil {
+	cm.OnPeerAudio = func(pcm16 []float32) {
+		ac, ok := s.reg.get(callID)
+		if !ok || ac.bridge == nil || ac.browserOpus == nil {
 			return
 		}
 		pcm48 := media.Upsample16to48(pcm16)
-		opus, err := oc.Encode(pcm48)
+		opus, err := ac.browserOpus.Encode(pcm48)
 		if err != nil || len(opus) == 0 {
 			return
 		}
-		_ = br.WriteOpus(opus, 60*time.Millisecond)
+		_ = ac.bridge.WriteOpus(opus, 60*time.Millisecond)
 	}
+}
+
+func (s *Session) startOutgoing(ctx context.Context, peer types.JID, isVideo bool) (string, error) {
+	callID := signaling.GenerateCallID()
+	cm := s.createCall(callID)
+	if err := cm.StartCall(ctx, callID, peer, isVideo); err != nil {
+		s.removeCall(callID)
+		return "", err
+	}
+	return callID, nil
+}
+
+func (s *Session) callForEvent(from types.JID, data *waBinary.Node) (*activeCall, bool) {
+	callID := callIDFromNode(wrapCall(from, data))
+	if callID == "" {
+		return nil, false
+	}
+	return s.reg.get(callID)
+}
+
+func (s *Session) onIncomingOffer(ctx context.Context, evt *events.CallOffer) {
+	node := wrapCall(evt.From, evt.Data)
+	callID := callIDFromNode(node)
+	if callID == "" {
+		return
+	}
+	if max := s.mgr.maxCalls; max > 0 && s.reg.count() >= max {
+		s.rejectOffer(ctx, node, evt.From)
+		return
+	}
+	cm := s.createCall(callID)
+	cm.HandleCallOffer(ctx, node, evt.From)
+}
+
+func (s *Session) rejectOffer(ctx context.Context, node *waBinary.Node, from types.JID) {
+	info := signaling.ExtractNodeInfo(node)
+	if info == nil {
+		return
+	}
+	creator := wanode.AttrString(info.InnerNode.Attrs, "call-creator")
+	if creator == "" {
+		creator = from.String()
+	}
+	reject := signaling.BuildRejectStanza(from, info.CallID, wanode.MustJID(creator))
+	_ = wa.NewSocket(s.client).SendNode(ctx, reject)
+	s.log.Info("inbound call rejected: session at capacity", "call_id", info.CallID)
 }
 
 func (s *Session) handleEvent(rawEvt any) {
@@ -107,15 +159,23 @@ func (s *Session) handleEvent(rawEvt any) {
 	case *events.LoggedOut:
 		s.setAuth(AuthSnapshot{State: "logged_out", Paired: false})
 	case *events.CallOffer:
-		s.cm.HandleCallOffer(ctx, wrapCall(evt.From, evt.Data), evt.From)
+		s.onIncomingOffer(ctx, evt)
 	case *events.CallAccept:
-		s.cm.HandleCallAccept(ctx, wrapCall(evt.From, evt.Data), evt.From)
+		if ac, ok := s.callForEvent(evt.From, evt.Data); ok {
+			ac.cm.HandleCallAccept(ctx, wrapCall(evt.From, evt.Data), evt.From)
+		}
 	case *events.CallTransport:
-		s.cm.HandleCallTransport(ctx, wrapCall(evt.From, evt.Data), evt.From)
+		if ac, ok := s.callForEvent(evt.From, evt.Data); ok {
+			ac.cm.HandleCallTransport(ctx, wrapCall(evt.From, evt.Data), evt.From)
+		}
 	case *events.CallTerminate:
-		s.cm.HandleCallTerminate(wrapCall(evt.From, evt.Data))
+		if ac, ok := s.callForEvent(evt.From, evt.Data); ok {
+			ac.cm.HandleCallTerminate(wrapCall(evt.From, evt.Data))
+		}
 	case *events.CallReject:
-		s.cm.HandleCallTerminate(wrapCall(evt.From, evt.Data))
+		if ac, ok := s.callForEvent(evt.From, evt.Data); ok {
+			ac.cm.HandleCallTerminate(wrapCall(evt.From, evt.Data))
+		}
 	}
 }
 
@@ -174,47 +234,65 @@ func (s *Session) info() SessionInfo {
 	return SessionInfo{ID: s.id, Name: s.name, JID: jid, State: a.State, Paired: a.Paired || jid != ""}
 }
 
-func (s *Session) setBridge(b *Bridge, oc media.Codec) {
-	s.mu.Lock()
-	old := s.bridge
-	oldOC := s.browserOpus
-	s.bridge = b
-	s.browserOpus = oc
-	s.mu.Unlock()
-	if old != nil {
-		old.Close()
+func (s *Session) setBridge(callID string, b *Bridge, oc media.Codec) {
+	oldB, oldOC, found := s.reg.setBridge(callID, b, oc)
+	if !found {
+		b.Close()
+		if oc != nil {
+			oc.Close()
+		}
+		return
+	}
+	if oldB != nil {
+		oldB.Close()
 	}
 	if oldOC != nil {
 		oldOC.Close()
 	}
 }
 
-func (s *Session) closeBridge() {
-	s.mu.Lock()
-	b := s.bridge
-	oc := s.browserOpus
-	s.bridge = nil
-	s.browserOpus = nil
-	s.mu.Unlock()
-	if b != nil {
-		b.Close()
+func (s *Session) removeCall(callID string) {
+	ac, ok := s.reg.remove(callID)
+	if !ok {
+		return
 	}
-	if oc != nil {
-		oc.Close()
+	if ac.bridge != nil {
+		ac.bridge.Close()
+	}
+	if ac.browserOpus != nil {
+		ac.browserOpus.Close()
+	}
+}
+
+func (s *Session) terminateCall(callID string, reason core.EndCallReason) {
+	ac, ok := s.reg.get(callID)
+	if !ok {
+		return
+	}
+	_ = ac.cm.EndCall(context.Background(), reason)
+}
+
+func (s *Session) teardownAllCalls() {
+	for _, ac := range s.reg.drain() {
+		_ = ac.cm.EndCall(context.Background(), core.EndCallReasonUserEnded)
+		if ac.bridge != nil {
+			ac.bridge.Close()
+		}
+		if ac.browserOpus != nil {
+			ac.browserOpus.Close()
+		}
 	}
 }
 
 func (s *Session) replaceClient(client *whatsmeow.Client) {
-	s.closeBridge()
+	s.teardownAllCalls()
 	s.client.Disconnect()
 	s.client = client
-	s.cm = call.NewCallManager(wa.NewSocket(client), s.log)
-	s.wireCallManager()
 	client.AddEventHandler(s.handleEvent)
 }
 
 func (s *Session) shutdown() {
-	s.closeBridge()
+	s.teardownAllCalls()
 	s.client.Disconnect()
 }
 

--- a/cmd/server/sessionmanager.go
+++ b/cmd/server/sessionmanager.go
@@ -151,7 +151,7 @@ func (m *SessionManager) Delete(ctx context.Context, id string) error {
 		s.client.Disconnect()
 		_ = m.container.DeleteDevice(ctx, s.client.Store)
 	}
-	s.closeBridge()
+	s.teardownAllCalls()
 	m.unregister(id)
 	_ = m.store.delete(ctx, id)
 	m.broker.emitSessionList(m.infos())

--- a/cmd/server/sessionmanager.go
+++ b/cmd/server/sessionmanager.go
@@ -19,13 +19,14 @@ type SessionManager struct {
 	store     *sessionStore
 	waLogger  waLog.Logger
 	log       *slog.Logger
+	maxCalls  int
 
 	mu       sync.RWMutex
 	sessions map[string]*Session
 	order    []string
 }
 
-func newSessionManager(ctx context.Context, container *sqlstore.Container, broker *Broker, store *sessionStore, waLogger waLog.Logger, log *slog.Logger) *SessionManager {
+func newSessionManager(ctx context.Context, container *sqlstore.Container, broker *Broker, store *sessionStore, waLogger waLog.Logger, log *slog.Logger, maxCalls int) *SessionManager {
 	return &SessionManager{
 		appCtx:    ctx,
 		container: container,
@@ -33,6 +34,7 @@ func newSessionManager(ctx context.Context, container *sqlstore.Container, broke
 		store:     store,
 		waLogger:  waLogger,
 		log:       log,
+		maxCalls:  maxCalls,
 		sessions:  map[string]*Session{},
 	}
 }

--- a/cmd/server/sessionmanager_test.go
+++ b/cmd/server/sessionmanager_test.go
@@ -30,7 +30,7 @@ func newTestManager(t *testing.T) *SessionManager {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return newSessionManager(ctx, container, NewBroker(), store, waLog.Noop, slog.Default())
+	return newSessionManager(ctx, container, NewBroker(), store, waLog.Noop, slog.Default(), 0)
 }
 
 func (m *SessionManager) addUnconnected(t *testing.T, name string) *Session {

--- a/internal/voip/call/callmanager.go
+++ b/internal/voip/call/callmanager.go
@@ -76,14 +76,13 @@ func (m *CallManager) emitState() {
 	}
 }
 
-func (m *CallManager) StartCall(ctx context.Context, peerJid types.JID, isVideo bool) (string, error) {
+func (m *CallManager) StartCall(ctx context.Context, callID string, peerJid types.JID, isVideo bool) error {
 	m.mu.Lock()
 	if m.currentCall != nil && !m.currentCall.IsEnded() {
 		m.mu.Unlock()
-		return "", &CallError{"a call is already in progress"}
+		return &CallError{"a call is already in progress"}
 	}
 
-	callID := signaling.GenerateCallID()
 	mediaType := core.CallMediaTypeAudio
 	if isVideo {
 		mediaType = core.CallMediaTypeVideo
@@ -110,11 +109,11 @@ func (m *CallManager) StartCall(ctx context.Context, peerJid types.JID, isVideo 
 
 	offer, err := signaling.BuildOfferStanza(ctx, m.sock, callID, callKey, resolved, isVideo)
 	if err != nil {
-		return "", err
+		return err
 	}
 	ackNode, err := m.sock.Query(ctx, offer)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	m.mu.Lock()
@@ -127,7 +126,7 @@ func (m *CallManager) StartCall(ctx context.Context, peerJid types.JID, isVideo 
 	}
 
 	m.log.Info("call offer sent", "call_id", callID, "peer", resolved.String())
-	return callID, nil
+	return nil
 }
 
 func (m *CallManager) AcceptCall(ctx context.Context, callID string) error {


### PR DESCRIPTION
## Summary

Lets a single paired WhatsApp account (session) run several concurrent, independent 1:1 calls, each owned by a different browser operator. Both outbound and inbound work concurrently. The React front-end was already multi-call, so no front-end changes were needed.

Approach: `CallManager` stays single-call; the `Session` becomes a registry/router keyed by `callId`. Events route via `signaling.ExtractNodeInfo(node).CallID`; each call gets its own `CallManager`, WebRTC bridge, and browser codec.

## Changes

- `Session` holds a `map[callId]*activeCall` registry instead of a single call manager + bridge; call events dispatch per `callId`.
- `StartCall` takes a pre-generated `callId`, removing an outbound registration race.
- New `-max-calls-per-session` flag (default 8, `0` = unlimited): outbound over the cap returns `429`, inbound is rejected with a busy stanza.
- One active call per operator (`clientId`): a second start/accept returns `409`.
- Operator drop: when the owning browser's WebRTC reaches ICE `Failed`/`Closed`, that call is torn down; other calls are unaffected.
- New unit tests: call registry, owner lookup, routing-key extraction.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass; `go build -tags mlow` (cgo native codec) OK.
- Validated live: two simultaneous outbound calls on the same account both reached `ACTIVE` with two-way audio, then terminated cleanly.
