### PR TITLE
feat(call): receive incoming calls (two-way audio) + outgoing ring timeout

### DIFF
--- a/internal/voip/call/callmanager.go
+++ b/internal/voip/call/callmanager.go
@@ -41,6 +41,7 @@ type CallManager struct {
 
 	lastCaptureAt time.Time
 	keepaliveStop chan struct{}
+	ringTimer     *time.Timer
 
 	OnStateChange func(*CallInfo)
 	OnIncoming    func(*CallInfo)
@@ -120,6 +121,7 @@ func (m *CallManager) StartCall(ctx context.Context, peerJid types.JID, isVideo 
 	m.mu.Lock()
 	_ = m.currentCall.ApplyTransition(Transition{Type: TransitionOfferSent})
 	m.emitState()
+	m.startRingTimeoutLocked(callID, ringTimeout)
 	m.mu.Unlock()
 
 	if ackNode != nil {
@@ -148,14 +150,20 @@ func (m *CallManager) AcceptCall(ctx context.Context, callID string) error {
 	creator := wanode.MustJID(call.CallCreator)
 	isVideo := call.MediaType == core.CallMediaTypeVideo
 	relayData := call.RelayData
+	// Incoming path: derive SRTP keys now. Without this m.srtpSession stays nil
+	// and no audio flows even after the relay connects.
+	m.initSrtpKeysLocked()
 	m.mu.Unlock()
 
 	if key != nil {
 		acceptNode, err := signaling.BuildAcceptStanza(ctx, m.sock, callID, key, peer, creator, isVideo)
 		if err != nil {
 			m.log.Error("build accept failed", "err", err)
-		} else if _, err := m.sock.Query(ctx, acceptNode); err != nil {
-			m.log.Error("accept query error", "err", err)
+		} else if err := m.sock.SendNode(ctx, acceptNode); err != nil {
+			// Fire-and-forget: a <call> ack is NOT routed back to Query, so using
+			// Query here stalls ~15s on timeout and delays the relay connect until
+			// after the caller has given up. Send and move straight to the relay.
+			m.log.Error("send accept error", "err", err)
 		}
 	}
 
@@ -202,6 +210,42 @@ func (m *CallManager) EndCall(ctx context.Context, reason core.EndCallReason) er
 	}
 	m.cleanupMedia()
 	return nil
+}
+
+// ringTimeout is how long an outgoing call rings before it auto-ends if the
+// peer never answers (mirrors WhatsApp's own caller timeout).
+const ringTimeout = 60 * time.Second
+
+// startRingTimeoutLocked (re)arms the no-answer timer for an outgoing call.
+// Must be called with m.mu held.
+func (m *CallManager) startRingTimeoutLocked(callID string, d time.Duration) {
+	if m.ringTimer != nil {
+		m.ringTimer.Stop()
+	}
+	m.ringTimer = time.AfterFunc(d, func() { m.onRingTimeout(callID) })
+	m.log.Debug("ring timeout armed", "call_id", callID, "after", d.String())
+}
+
+// cancelRingTimeoutLocked stops the no-answer timer. Must be called with m.mu held.
+func (m *CallManager) cancelRingTimeoutLocked() {
+	if m.ringTimer != nil {
+		m.ringTimer.Stop()
+		m.ringTimer = nil
+	}
+}
+
+// onRingTimeout ends the call if it is still ringing (unanswered) when the timer
+// fires. A call that was answered or already ended is left untouched.
+func (m *CallManager) onRingTimeout(callID string) {
+	m.mu.Lock()
+	call := m.currentCall
+	if call == nil || call.CallID != callID || !call.IsRinging() {
+		m.mu.Unlock()
+		return
+	}
+	m.mu.Unlock()
+	m.log.Info("call ring timeout — no answer", "call_id", callID)
+	_ = m.EndCall(context.Background(), core.EndCallReasonTimeout)
 }
 
 func (m *CallManager) ownCredJid() string {

--- a/internal/voip/call/callmanager_relay.go
+++ b/internal/voip/call/callmanager_relay.go
@@ -77,6 +77,7 @@ func (m *CallManager) connectRelays(endpoints []core.RelayEndpoint) {
 
 func (m *CallManager) cleanupMedia() {
 	m.mu.Lock()
+	m.cancelRingTimeoutLocked()
 	codec := m.codec
 	m.codec = nil
 	if m.keepaliveStop != nil {

--- a/internal/voip/call/callmanager_signaling.go
+++ b/internal/voip/call/callmanager_signaling.go
@@ -27,7 +27,11 @@ func (m *CallManager) HandleCallOffer(ctx context.Context, node *waBinary.Node, 
 	if err != nil {
 		m.log.Error("offer decrypt call key", "err", err)
 	}
-	relays := signaling.ExtractRelayEndpoints(info.InnerNode)
+	// The offer carries its relay endpoints in a <relay> block (<te2>/<token>/
+	// <key>/<hbh_key>), the same structure as the offer-ack — so use the parser
+	// that already works for outgoing calls. The legacy ExtractRelayEndpoints only
+	// understood a <relay ip=.. token=..> attribute form and returned 0 here.
+	parsedRelay := signaling.ParseRelayFromAck(info.InnerNode)
 
 	mediaType := core.CallMediaTypeAudio
 	if isVideo {
@@ -39,8 +43,15 @@ func (m *CallManager) HandleCallOffer(ctx context.Context, node *waBinary.Node, 
 	if callKey != nil {
 		call.EncryptionKey = callKey
 	}
-	if len(relays) > 0 {
-		call.RelayData = &core.RelayData{Endpoints: relays}
+	if len(parsedRelay.Relays) > 0 {
+		call.RelayData = &core.RelayData{
+			Endpoints:       parsedRelay.Relays,
+			ParticipantJids: parsedRelay.ParticipantJids,
+			UUID:            parsedRelay.UUID,
+			SelfPid:         parsedRelay.SelfPid,
+			PeerPid:         parsedRelay.PeerPid,
+			HbhKey:          parsedRelay.HbhKey,
+		}
 	}
 	m.currentCall = call
 	m.initialTransportSent = false
@@ -67,7 +78,7 @@ func (m *CallManager) HandleCallOffer(ctx context.Context, node *waBinary.Node, 
 	m.mu.Lock()
 	m.emitState()
 	m.mu.Unlock()
-	m.log.Info("incoming call", "call_id", callID, "peer", peerJid.String(), "video", isVideo, "relays", len(relays))
+	m.log.Info("incoming call", "call_id", callID, "peer", peerJid.String(), "video", isVideo, "relays", len(parsedRelay.Relays))
 }
 
 func (m *CallManager) HandleCallAccept(ctx context.Context, node *waBinary.Node, peerJid types.JID) {
@@ -94,6 +105,7 @@ func (m *CallManager) HandleCallAccept(ctx context.Context, node *waBinary.Node,
 
 	m.mu.Lock()
 	_ = call.ApplyTransition(Transition{Type: TransitionRemoteAccepted})
+	m.cancelRingTimeoutLocked() // answered — stop the no-answer timer
 	m.emitState()
 	m.acceptedByJid = peerJid.String()
 	if m.peerSsrcs == nil || !m.actualPeerSet {


### PR DESCRIPTION
## What
Makes **incoming** calls work end-to-end (the app could only place outgoing calls before), plus a small outgoing-call quality-of-life fix.

### Receive incoming calls (verified with two-way audio)
- **`HandleCallOffer`** — parse the offer's `<relay>` block (the `<te2>`/`<token>`/`<key>`/`<hbh_key>` structure) with `ParseRelayFromAck`, the same parser the outgoing path already uses. The old `ExtractRelayEndpoints` expected a `<relay ip=.. token=..>` attribute form that WhatsApp doesn't send, so it parsed **0 relays** and an accepted call had nowhere to connect.
- **`AcceptCall`** — derive the SRTP keys (`initSrtpKeysLocked`) on accept; without them the relay connects but stays **mute**. Send the `<accept>` via `SendNode` instead of `Query`: a `<call>` ack isn't routed back to `Query`, so it **stalled ~15s** on timeout and the relay connect happened only after the caller had hung up.

### Outgoing ring timeout
An unanswered outgoing call now **auto-ends after 60s** (mirrors WhatsApp's caller timeout) instead of ringing until the user hangs up. Armed when the offer is sent; cancelled on answer or teardown.

## Testing
- Outgoing: places calls, resolves relays, media connects (unchanged path).
- Incoming: called the paired number from a second phone → rang → accepted in the browser → **talked normally (two-way audio)**.
- `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./internal/voip/call/ ./cmd/server/` all pass.

## Note
For stable two-way audio this pairs with the codec thread-safety fix (separate PR): once audio flows both directions, the `opus_mlow` codec must be called serially or it crashes the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)