### PR TITLE
Fix dev API proxy target to match the server port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ client/node_modules/
 client/dist/
 client/.vite/
 client/*.tsbuildinfo
+.env
+.env.*
+!.env.example
 node_modules/
 npm-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ cd client
 npm run dev      # Vite on :5173, proxies /api → http://localhost:8080
 ```
 
+The proxy target defaults to `http://localhost:8080` (the server's default
+`-addr`), so dev mode works with no extra config. If you run the server on a
+different host or port, copy `client/.env.example` to `client/.env` and set
+`VITE_API_PROXY_TARGET` to match.
+
 For production, build the static client and serve it from the Go server:
 
 ```bash

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+# Set only if the Go server runs on a non-default host/port (default :8080).
+VITE_API_PROXY_TARGET=http://localhost:8080

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,16 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "node:url";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      "/api": { target: "http://localhost:3001", changeOrigin: true, ws: false },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const apiTarget = env.VITE_API_PROXY_TARGET || "http://localhost:8080";
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
     },
-  },
+    server: {
+      port: 5173,
+      proxy: {
+        "/api": { target: apiTarget, changeOrigin: true, ws: false },
+      },
+    },
+  };
 });


### PR DESCRIPTION
Fixed dev mode being broken out of the box: the Vite dev proxy targeted `:3001` while the Go server defaults to `:8080`, so every `/api` request failed with `ECONNREFUSED` and surfaced in the browser as HTTP 500.

This points the proxy at `:8080` and makes it overridable via `VITE_API_PROXY_TARGET` (fallback `:8080`), so it can follow a server started on another port.
