### PR TITLE
feat(recording): implement server-side call recording to WAV

### DIFF
--- a/cmd/server/callregistry.go
+++ b/cmd/server/callregistry.go
@@ -7,8 +7,9 @@ import (
 )
 
 type activeCall struct {
-	cm     *call.CallManager
-	bridge *Bridge
+	cm       *call.CallManager
+	bridge   *Bridge
+	recorder *Recorder
 }
 
 type callRegistry struct {

--- a/cmd/server/httpapi.go
+++ b/cmd/server/httpapi.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -191,6 +192,17 @@ func (s *server) doStartCall(sess *Session, w http.ResponseWriter, r *http.Reque
 		SessionID: sess.id, CallID: callID, Owner: &owner, Direction: "outbound", Peer: peer.String(),
 		StartedAt: time.Now().UnixMilli(), Status: StatusRinging,
 	})
+	if body.Record && s.recordingsDir != "" {
+		_ = os.MkdirAll(s.recordingsDir, 0o755)
+		recPath := filepath.Join(s.recordingsDir, callID+".wav")
+		if rec, err := NewRecorder(recPath); err == nil {
+			if ac, ok := sess.reg.get(callID); ok {
+				ac.recorder = rec
+			}
+		} else {
+			s.log.Warn("recorder create failed", "path", recPath, "err", err)
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"call": map[string]string{"callId": callID}})
 }
 
@@ -216,6 +228,9 @@ func (s *server) doWebRTC(sess *Session, w http.ResponseWriter, r *http.Request)
 
 	bridge.OnBrowserPCM = func(pcm []float32) {
 		ac.cm.FeedCapturedPCM(pcm)
+		if ac.recorder != nil {
+			ac.recorder.Write(pcm)
+		}
 	}
 	bridge.OnTerminalICE = func() {
 		go sess.terminateCall(callID, core.EndCallReasonUserEnded)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ func main() {
 	staticDir := flag.String("static", "client/dist", "static client directory (optional)")
 	debug := flag.Bool("debug", false, "verbose logging")
 	maxCalls := flag.Int("max-calls-per-session", 8, "max concurrent calls per session (0 = unlimited)")
+	recordingsDir := flag.String("recordings", "recordings", "directory for call recordings (empty to disable)")
 	flag.Parse()
 
 	level := slog.LevelInfo
@@ -30,7 +31,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	srv, err := newServer(ctx, *dbPath, *staticDir, *maxCalls, log)
+	srv, err := newServer(ctx, *dbPath, *staticDir, *maxCalls, *recordingsDir, log)
 	if err != nil {
 		log.Error("startup failed", "err", err)
 		os.Exit(1)

--- a/cmd/server/recorder.go
+++ b/cmd/server/recorder.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/binary"
+	"os"
+	"sync"
+)
+
+type Recorder struct {
+	mu      sync.Mutex
+	f       *os.File
+	samples uint32
+}
+
+func NewRecorder(path string) (*Recorder, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	r := &Recorder{f: f}
+	if err := r.writeHeaderLocked(0); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return r, nil
+}
+
+// writeHeaderLocked writes (or overwrites) the 44-byte WAV header.
+// Must be called with mu held or before the recorder is shared.
+func (r *Recorder) writeHeaderLocked(dataBytes uint32) error {
+	const (
+		sampleRate = 16000
+		channels   = 1
+		bitDepth   = 16
+		byteRate   = sampleRate * channels * bitDepth / 8
+		blockAlign = channels * bitDepth / 8
+	)
+	if _, err := r.f.Seek(0, 0); err != nil {
+		return err
+	}
+	var buf [44]byte
+	copy(buf[0:], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:], 36+dataBytes)
+	copy(buf[8:], "WAVE")
+	copy(buf[12:], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:], 16)
+	binary.LittleEndian.PutUint16(buf[20:], 1) // PCM
+	binary.LittleEndian.PutUint16(buf[22:], channels)
+	binary.LittleEndian.PutUint32(buf[24:], sampleRate)
+	binary.LittleEndian.PutUint32(buf[28:], byteRate)
+	binary.LittleEndian.PutUint16(buf[32:], blockAlign)
+	binary.LittleEndian.PutUint16(buf[34:], bitDepth)
+	copy(buf[36:], "data")
+	binary.LittleEndian.PutUint32(buf[40:], dataBytes)
+	_, err := r.f.Write(buf[:])
+	return err
+}
+
+// Write appends PCM samples to the recording. Safe to call from multiple goroutines.
+func (r *Recorder) Write(pcm []float32) {
+	if len(pcm) == 0 {
+		return
+	}
+	buf := make([]byte, len(pcm)*2)
+	for i, s := range pcm {
+		if s > 1 {
+			s = 1
+		} else if s < -1 {
+			s = -1
+		}
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(int16(s*32767)))
+	}
+	r.mu.Lock()
+	_, _ = r.f.Write(buf)
+	r.samples += uint32(len(pcm))
+	r.mu.Unlock()
+}
+
+// Close finalises the WAV header with the correct data size and closes the file.
+func (r *Recorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	dataBytes := r.samples * 2 // 16-bit mono: 2 bytes per sample
+	if err := r.writeHeaderLocked(dataBytes); err != nil {
+		r.f.Close()
+		return err
+	}
+	return r.f.Close()
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -11,10 +11,11 @@ import (
 )
 
 type server struct {
-	broker    *Broker
-	sessions  *SessionManager
-	log       *slog.Logger
-	staticDir string
+	broker        *Broker
+	sessions      *SessionManager
+	log           *slog.Logger
+	staticDir     string
+	recordingsDir string
 }
 
 func openDB(dbPath string) (*sql.DB, error) {
@@ -27,7 +28,7 @@ func openDB(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
-func newServer(ctx context.Context, dbPath, staticDir string, maxCalls int, log *slog.Logger) (*server, error) {
+func newServer(ctx context.Context, dbPath, staticDir string, maxCalls int, recordingsDir string, log *slog.Logger) (*server, error) {
 	db, err := openDB(dbPath)
 	if err != nil {
 		return nil, err
@@ -50,5 +51,5 @@ func newServer(ctx context.Context, dbPath, staticDir string, maxCalls int, log 
 	mgr := newSessionManager(ctx, container, broker, store, waLogger, log, maxCalls)
 	broker.SnapshotFn = mgr.snapshotEvents
 
-	return &server{broker: broker, sessions: mgr, log: log, staticDir: staticDir}, nil
+	return &server{broker: broker, sessions: mgr, log: log, staticDir: staticDir, recordingsDir: recordingsDir}, nil
 }

--- a/cmd/server/session.go
+++ b/cmd/server/session.go
@@ -93,6 +93,9 @@ func (s *Session) wireCall(cm *call.CallManager, callID string) {
 			return
 		}
 		_ = ac.bridge.WritePCM(pcm16)
+		if ac.recorder != nil {
+			ac.recorder.Write(pcm16)
+		}
 	}
 }
 
@@ -247,6 +250,11 @@ func (s *Session) removeCall(callID string) {
 	if ac.bridge != nil {
 		ac.bridge.Close()
 	}
+	if ac.recorder != nil {
+		if err := ac.recorder.Close(); err != nil {
+			s.log.Warn("recorder close failed", "call", callID, "err", err)
+		}
+	}
 }
 
 func (s *Session) terminateCall(callID string, reason core.EndCallReason) {
@@ -262,6 +270,9 @@ func (s *Session) teardownAllCalls() {
 		_ = ac.cm.EndCall(context.Background(), core.EndCallReasonUserEnded)
 		if ac.bridge != nil {
 			ac.bridge.Close()
+		}
+		if ac.recorder != nil {
+			_ = ac.recorder.Close()
 		}
 	}
 }


### PR DESCRIPTION
Wires up the previously unused `record` flag from the start-call API into a full recording pipeline that writes a mono 16 kHz/16-bit WAV file for each recorded call.

Changes:
- cmd/server/recorder.go (new): thread-safe WAV writer that opens a file with a placeholder header, appends raw PCM as it arrives, and seeks back on Close() to patch the RIFF/data chunk sizes so the file is always well-formed.
- cmd/server/callregistry.go: adds `recorder *Recorder` field to `activeCall` so the recorder travels with the call throughout its lifetime.
- cmd/server/server.go + main.go: adds `recordingsDir` field to the server struct and a `-recordings` CLI flag (default: "recordings"). Pass an empty string to disable recording entirely.
- cmd/server/httpapi.go: in `doStartCall`, creates the WAV file and attaches the recorder to the activeCall when `record: true`; in `doWebRTC`, taps `OnBrowserPCM` to also write the operator's microphone audio to the recorder.
- cmd/server/session.go: taps `OnPeerAudio` in `wireCall` to write the remote peer's audio; closes the recorder in both `removeCall` and `teardownAllCalls` to ensure the WAV header is finalised even on abrupt shutdown.