### PR TITLE
feat: add generic private PCM AgentProvider bridge

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,6 +20,7 @@ func main() {
 	staticDir := flag.String("static", "client/dist", "static client directory (optional)")
 	debug := flag.Bool("debug", false, "verbose logging")
 	maxCalls := flag.Int("max-calls-per-session", 8, "max concurrent calls per session (0 = unlimited)")
+	unixSocket := flag.String("unix-socket", envOrDefault("WACALLS_SOCKET", "/run/ligacao-ai/wacalls.sock"), "private local PCM Unix socket (empty disables it)")
 	flag.Parse()
 
 	level := slog.LevelInfo
@@ -52,8 +53,15 @@ func main() {
 		log.Error("startup failed", "err", err)
 		os.Exit(1)
 	}
-	if err := srv.Run(ctx, *addr); err != nil {
+	if err := srv.Run(ctx, *addr, *unixSocket); err != nil {
 		log.Error("server error", "err", err)
 		os.Exit(1)
 	}
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/internal/app/broker.go
+++ b/internal/app/broker.go
@@ -225,8 +225,6 @@ func (b *Broker) serveSSE(w http.ResponseWriter, r *http.Request, clientID strin
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
 	sub := b.subscribe(clientID)
 	defer b.unsubscribe(sub)
 

--- a/internal/app/httpapi.go
+++ b/internal/app/httpapi.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -43,16 +45,45 @@ func (s *Server) routes() http.Handler {
 			mux.Handle("/", http.FileServer(http.Dir(s.staticDir)))
 		}
 	}
-	return withCORS(mux)
+	return withAdminAuth(withCORS(mux), s.adminToken)
 }
 
 func withCORS(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Client-Id")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin != "" {
+			parsed, err := url.Parse(origin)
+			if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host != r.Host {
+				http.Error(w, "cross-origin request denied", http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Client-Id")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		}
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+func withAdminAuth(h http.Handler, token string) http.Handler {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return h
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/") && !strings.HasPrefix(r.URL.Path, "/debug/") {
+			h.ServeHTTP(w, r)
+			return
+		}
+		provided := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		if len(provided) != len(token) || subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="WaCalls"`)
+			http.Error(w, "authentication required", http.StatusUnauthorized)
 			return
 		}
 		h.ServeHTTP(w, r)

--- a/internal/app/httpapi_security_test.go
+++ b/internal/app/httpapi_security_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAdminAuthProtectsAPIInConstantScope(t *testing.T) {
+	handler := withAdminAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}), "secret-token")
+
+	for _, tc := range []struct {
+		name   string
+		header string
+		want   int
+	}{
+		{name: "missing", want: http.StatusUnauthorized},
+		{name: "wrong", header: "Bearer other", want: http.StatusUnauthorized},
+		{name: "valid", header: "Bearer secret-token", want: http.StatusNoContent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/sessions", nil)
+			req.Header.Set("Authorization", tc.header)
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, req)
+			if res.Code != tc.want {
+				t.Fatalf("status=%d want=%d", res.Code, tc.want)
+			}
+		})
+	}
+}
+
+func TestCORSAllowsOnlyExactSameOrigin(t *testing.T) {
+	handler := withCORS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	allowed := httptest.NewRequest(http.MethodOptions, "http://127.0.0.1:8080/api/sessions", nil)
+	allowed.Header.Set("Origin", "http://127.0.0.1:8080")
+	allowedResult := httptest.NewRecorder()
+	handler.ServeHTTP(allowedResult, allowed)
+	if allowedResult.Code != http.StatusNoContent || allowedResult.Header().Get("Access-Control-Allow-Origin") != "http://127.0.0.1:8080" {
+		t.Fatalf("same-origin preflight failed: status=%d origin=%q", allowedResult.Code, allowedResult.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	denied := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/sessions", nil)
+	denied.Header.Set("Origin", "https://evil.example")
+	deniedResult := httptest.NewRecorder()
+	handler.ServeHTTP(deniedResult, denied)
+	if deniedResult.Code != http.StatusForbidden || deniedResult.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("cross-origin request was not denied: status=%d origin=%q", deniedResult.Code, deniedResult.Header().Get("Access-Control-Allow-Origin"))
+	}
+}

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"wacalls/internal/store"
@@ -15,11 +16,12 @@ import (
 )
 
 type Server struct {
-	broker    *Broker
-	sessions  *SessionManager
-	log       *slog.Logger
-	staticDir string
-	debug     bool
+	broker     *Broker
+	sessions   *SessionManager
+	log        *slog.Logger
+	staticDir  string
+	debug      bool
+	adminToken string
 }
 
 func NewServer(ctx context.Context, storeCfg store.Config, staticDir string, maxCalls int, debug bool, obsFactory func(string) core.CallObserver, tracer telemetry.CallTracer, log *slog.Logger) (*Server, error) {
@@ -37,13 +39,24 @@ func NewServer(ctx context.Context, storeCfg store.Config, staticDir string, max
 	mgr := newSessionManager(ctx, bundle.Container, broker, bundle.Sessions, waLogger, log, maxCalls, obsFactory, tracer)
 	broker.SnapshotFn = mgr.snapshotEvents
 
-	return &Server{broker: broker, sessions: mgr, log: log, staticDir: staticDir, debug: debug}, nil
+	return &Server{
+		broker: broker, sessions: mgr, log: log, staticDir: staticDir,
+		debug: debug, adminToken: os.Getenv("WACALLS_ADMIN_TOKEN"),
+	}, nil
 }
 
-func (s *Server) Run(ctx context.Context, addr string) error {
+func (s *Server) Run(ctx context.Context, addr, unixSocketPath string) error {
 	defer s.sessions.disconnectAll()
 	if err := s.sessions.Restore(ctx); err != nil {
 		return err
+	}
+	var unixServer *unixPCMServer
+	if unixSocketPath != "" {
+		unixServer = newUnixPCMServer(unixSocketPath, sessionLocalBackend{sessions: s.sessions}, s.log)
+		if err := unixServer.Start(ctx); err != nil {
+			return err
+		}
+		defer func() { _ = unixServer.Close() }()
 	}
 	httpSrv := &http.Server{Addr: addr, Handler: s.routes()}
 	go func() {

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -33,6 +33,8 @@ type Session struct {
 
 	bridgeMu sync.Mutex
 	bridges  map[string]*Bridge
+	localMu  sync.Mutex
+	local    map[string]localCallObserver
 
 	mu   sync.Mutex
 	auth AuthSnapshot
@@ -47,6 +49,7 @@ func newSession(mgr *SessionManager, id, name string, client *whatsmeow.Client) 
 		client:  client,
 		auth:    AuthSnapshot{State: "connecting"},
 		bridges: map[string]*Bridge{},
+		local:   map[string]localCallObserver{},
 	}
 	s.calls = call.NewClient(wa.NewSocket(client), s.log, s.makeExtensions, mgr.maxCalls, s.wireCall, mgr.newObserver)
 	client.AddEventHandler(s.handleEvent)
@@ -74,6 +77,9 @@ func (s *Session) wireCall(callID string, cm *call.CallManager) {
 		s.mgr.tracer.StartCall(c.CallID, telemetry.CallAttrs{Session: s.id, Peer: c.PeerJid, Direction: "inbound", Video: c.MediaType == core.CallMediaTypeVideo})
 	}
 	cm.OnStateChange = func(c *call.CallInfo) {
+		if sink := s.localCall(callID); sink != nil {
+			sink.onState(c)
+		}
 		if c.IsEnded() {
 			s.mgr.tracer.EndCall(c.CallID, endResult(c), string(c.StateData.EndReason), endDuration(c))
 			s.removeCall(c.CallID)
@@ -102,11 +108,17 @@ func (s *Session) wireCall(callID string, cm *call.CallManager) {
 		s.mgr.broker.upsertCall(rec)
 	}
 	cm.OnEnded = func(c *call.CallInfo) {
+		if sink := s.localCall(callID); sink != nil {
+			sink.onState(c)
+		}
 		s.mgr.tracer.EndCall(c.CallID, endResult(c), string(c.StateData.EndReason), endDuration(c))
 		s.removeCall(c.CallID)
 		s.mgr.broker.endCall(c.CallID, string(c.StateData.EndReason))
 	}
 	cm.OnPeerAudio = func(pcm16 []float32) {
+		if sink := s.localCall(callID); sink != nil {
+			sink.onPeerPCM(pcm16)
+		}
 		if b := s.getBridge(callID); b != nil {
 			_ = b.WritePCM(pcm16)
 		}
@@ -120,6 +132,26 @@ func (s *Session) wireCall(callID string, cm *call.CallManager) {
 
 func (s *Session) startOutgoing(ctx context.Context, peer types.JID, isVideo bool) (string, error) {
 	return s.calls.StartCall(ctx, peer, isVideo)
+}
+
+func (s *Session) startLocalOutgoing(ctx context.Context, peer types.JID, sink localCallObserver) (string, error) {
+	callID, err := s.calls.StartCallWithSetup(ctx, peer, false, func(callID string, cm *call.CallManager) {
+		s.localMu.Lock()
+		s.local[callID] = sink
+		s.localMu.Unlock()
+		sink.bound(s, callID, cm)
+	})
+	if err != nil {
+		s.localMu.Lock()
+		for id, candidate := range s.local {
+			if candidate == sink {
+				delete(s.local, id)
+			}
+		}
+		s.localMu.Unlock()
+		return "", err
+	}
+	return callID, nil
 }
 
 func (s *Session) callFor(callID string) (*call.CallManager, bool) {
@@ -237,6 +269,9 @@ func (s *Session) removeCall(callID string) {
 	if b != nil {
 		b.Close()
 	}
+	if sink := s.detachLocalCall(callID); sink != nil {
+		sink.closed()
+	}
 	s.calls.Remove(callID)
 }
 
@@ -257,6 +292,28 @@ func (s *Session) teardownAllCalls() {
 			b.Close()
 		}
 	}
+	s.localMu.Lock()
+	local := s.local
+	s.local = map[string]localCallObserver{}
+	s.localMu.Unlock()
+	for _, sink := range local {
+		sink.closed()
+	}
+}
+
+func (s *Session) localCall(callID string) localCallObserver {
+	s.localMu.Lock()
+	sink := s.local[callID]
+	s.localMu.Unlock()
+	return sink
+}
+
+func (s *Session) detachLocalCall(callID string) localCallObserver {
+	s.localMu.Lock()
+	sink := s.local[callID]
+	delete(s.local, callID)
+	s.localMu.Unlock()
+	return sink
 }
 
 func (s *Session) replaceClient(client *whatsmeow.Client) {

--- a/internal/app/unixbridge.go
+++ b/internal/app/unixbridge.go
@@ -1,0 +1,950 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"wacalls/internal/voip/call"
+	"wacalls/internal/voip/core"
+	"wacalls/internal/voip/media"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+const (
+	unixFrameControlRequest byte = 0x01
+	unixFrameControlEvent   byte = 0x02
+	unixFrameInboundPCM     byte = 0x10
+	unixFrameOutboundPCM    byte = 0x11
+	unixFrameFallbackPCM    byte = 0x12
+
+	unixMaxFrameSize      = 1 << 20
+	unixPCMRate           = 16_000
+	unixPCMChannels       = 1
+	unixPCMBytesPerSecond = unixPCMRate * 2
+	unixMaxFallbackBytes  = 5 * unixPCMBytesPerSecond
+	unixMaxPlaybackBytes  = 10 * unixPCMBytesPerSecond
+	unixPCMChunkBytes     = 640 // 20 ms of mono PCM16 at 16 kHz.
+	unixCodecFrameBytes   = 1_920
+)
+
+var errUnixSessionDone = errors.New("local PCM session finished")
+
+type localCallEvent struct {
+	Event  string `json:"event"`
+	CallID string `json:"call_id,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (e localCallEvent) terminal() bool {
+	return e.Event == "busy" || e.Event == "ended" || e.Event == "error"
+}
+
+type localPCMCall interface {
+	InboundPCM() <-chan []byte
+	Events() <-chan localCallEvent
+	SendPCM([]byte) error
+	PlayFallback([]byte) error
+	FlushPlayback() error
+	End(context.Context, string) error
+}
+
+type localPCMBackend interface {
+	StartOutbound(context.Context, string, string) (localPCMCall, error)
+}
+
+// unixPCMServer owns a private AF_UNIX listener. It deliberately has no HTTP
+// handler and does not expose WhatsApp session or QR material.
+type unixPCMServer struct {
+	path    string
+	backend localPCMBackend
+	log     *slog.Logger
+
+	mu       sync.Mutex
+	listener net.Listener
+	active   *unixPCMConn
+	closed   bool
+	wg       sync.WaitGroup
+}
+
+func newUnixPCMServer(path string, backend localPCMBackend, log *slog.Logger) *unixPCMServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &unixPCMServer{path: path, backend: backend, log: log}
+}
+
+func (s *unixPCMServer) Start(ctx context.Context) error {
+	if !filepath.IsAbs(s.path) {
+		return fmt.Errorf("local PCM socket path must be absolute")
+	}
+	dir := filepath.Dir(s.path)
+	info, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("create local PCM socket directory: %w", err)
+		}
+		if err := os.Chmod(dir, 0o750); err != nil {
+			return fmt.Errorf("secure local PCM socket directory: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("inspect local PCM socket directory: %w", err)
+	} else if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("local PCM socket parent must be a real directory")
+	} else if info.Mode().Perm() != 0o750 {
+		return fmt.Errorf("local PCM socket directory permissions are %#o, want 0750", info.Mode().Perm())
+	}
+	if err := removeStaleUnixSocket(s.path); err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("unix", s.path)
+	if err != nil {
+		return fmt.Errorf("listen on local PCM socket: %w", err)
+	}
+	if err := os.Chmod(s.path, 0o660); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(s.path)
+		return fmt.Errorf("secure local PCM socket: %w", err)
+	}
+
+	s.mu.Lock()
+	s.listener = listener
+	s.mu.Unlock()
+	s.wg.Add(1)
+	go s.acceptLoop(ctx, listener)
+	go func() {
+		<-ctx.Done()
+		_ = s.Close()
+	}()
+	s.log.Info("local PCM socket listening", "path", s.path)
+	return nil
+}
+
+func (s *unixPCMServer) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	listener := s.listener
+	active := s.active
+	s.mu.Unlock()
+
+	if active != nil {
+		active.close()
+	}
+	var err error
+	if listener != nil {
+		err = listener.Close()
+	}
+	s.wg.Wait()
+	if removeErr := os.Remove(s.path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) && err == nil {
+		err = removeErr
+	}
+	return err
+}
+
+func (s *unixPCMServer) acceptLoop(ctx context.Context, listener net.Listener) {
+	defer s.wg.Done()
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() == nil && !errors.Is(err, net.ErrClosed) {
+				s.log.Error("local PCM accept failed", "err", err)
+			}
+			return
+		}
+		client := &unixPCMConn{server: s, conn: conn, log: s.log}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			client.serve(ctx)
+		}()
+	}
+}
+
+func (s *unixPCMServer) claim(client *unixPCMConn) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.active != nil {
+		return false
+	}
+	s.active = client
+	return true
+}
+
+func (s *unixPCMServer) release(client *unixPCMConn) {
+	s.mu.Lock()
+	if s.active == client {
+		s.active = nil
+	}
+	s.mu.Unlock()
+}
+
+func removeStaleUnixSocket(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect local PCM socket: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to replace non-socket path %s", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove stale local PCM socket: %w", err)
+	}
+	return nil
+}
+
+type unixPCMConn struct {
+	server *unixPCMServer
+	conn   net.Conn
+	log    *slog.Logger
+
+	writeMu sync.Mutex
+	closeMu sync.Once
+	call    localPCMCall
+	callID  string
+	claimed bool
+	ended   bool
+}
+
+func (c *unixPCMConn) serve(serverCtx context.Context) {
+	defer func() {
+		if c.call != nil && !c.ended {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			_ = c.call.End(ctx, "worker_disconnected")
+			cancel()
+		}
+		if c.claimed {
+			c.server.release(c)
+		}
+		c.close()
+	}()
+
+	_ = c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		frameType, payload, err := readUnixFrame(c.conn)
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) && serverCtx.Err() == nil {
+				c.log.Debug("local PCM connection closed", "err", err)
+			}
+			return
+		}
+		if err := c.handleFrame(serverCtx, frameType, payload); err != nil {
+			if !errors.Is(err, errUnixSessionDone) {
+				_ = c.writeEvent(localCallEvent{Event: "error", CallID: c.callID, Error: err.Error()})
+			}
+			return
+		}
+	}
+}
+
+func (c *unixPCMConn) handleFrame(ctx context.Context, frameType byte, payload []byte) error {
+	switch frameType {
+	case unixFrameControlRequest:
+		return c.handleControl(ctx, payload)
+	case unixFrameOutboundPCM:
+		if c.call == nil {
+			return errors.New("start command required before PCM")
+		}
+		return c.call.SendPCM(payload)
+	case unixFrameFallbackPCM:
+		if c.call == nil {
+			return errors.New("start command required before fallback PCM")
+		}
+		return c.call.PlayFallback(payload)
+	default:
+		return fmt.Errorf("frame type 0x%02x is not accepted from worker", frameType)
+	}
+}
+
+func (c *unixPCMConn) handleControl(ctx context.Context, payload []byte) error {
+	var envelope struct {
+		Op string `json:"op"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return fmt.Errorf("decode control command: %w", err)
+	}
+	switch envelope.Op {
+	case "start":
+		if c.call != nil || c.claimed {
+			return errors.New("call already started on this connection")
+		}
+		var command struct {
+			Op         string `json:"op"`
+			CallID     string `json:"call_id"`
+			To         string `json:"to"`
+			SampleRate int    `json:"sample_rate"`
+			Channels   int    `json:"channels"`
+		}
+		decoder := json.NewDecoder(bytes.NewReader(payload))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&command); err != nil {
+			return fmt.Errorf("decode start command: %w", err)
+		}
+		if err := validateStartCommand(command.CallID, command.To, command.SampleRate, command.Channels); err != nil {
+			return err
+		}
+		c.callID = command.CallID
+		if !c.server.claim(c) {
+			_ = c.writeEvent(localCallEvent{Event: "busy", CallID: command.CallID, Reason: "capacity"})
+			return errUnixSessionDone
+		}
+		c.claimed = true
+		localCall, err := c.server.backend.StartOutbound(ctx, command.CallID, command.To)
+		if err != nil {
+			c.server.release(c)
+			c.claimed = false
+			return fmt.Errorf("start outbound call: %w", err)
+		}
+		c.call = localCall
+		_ = c.conn.SetReadDeadline(time.Time{})
+		go c.forward(localCall)
+		return nil
+	case "flush_playback":
+		if c.call == nil {
+			return errors.New("start command required before flush")
+		}
+		return c.call.FlushPlayback()
+	case "end":
+		if c.call == nil {
+			return errors.New("start command required before end")
+		}
+		var command struct {
+			Op     string `json:"op"`
+			Reason string `json:"reason"`
+		}
+		decoder := json.NewDecoder(bytes.NewReader(payload))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&command); err != nil {
+			return fmt.Errorf("decode end command: %w", err)
+		}
+		command.Reason = strings.TrimSpace(command.Reason)
+		if command.Reason == "" {
+			command.Reason = "worker_ended"
+		}
+		if len(command.Reason) > 128 {
+			return errors.New("end reason exceeds 128 bytes")
+		}
+		c.ended = true
+		endCtx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		err := c.call.End(endCtx, command.Reason)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("end outbound call: %w", err)
+		}
+		return errUnixSessionDone
+	default:
+		return fmt.Errorf("unsupported control operation %q", envelope.Op)
+	}
+}
+
+func (c *unixPCMConn) forward(localCall localPCMCall) {
+	pcm := localCall.InboundPCM()
+	events := localCall.Events()
+	for pcm != nil || events != nil {
+		select {
+		case payload, ok := <-pcm:
+			if !ok {
+				pcm = nil
+				continue
+			}
+			if err := validatePCM(payload, unixMaxFrameSize); err != nil {
+				_ = c.writeEvent(localCallEvent{Event: "error", CallID: c.callID, Error: err.Error()})
+				c.close()
+				return
+			}
+			if err := c.writeFrame(unixFrameInboundPCM, payload); err != nil {
+				return
+			}
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
+			if event.CallID == "" {
+				event.CallID = c.callID
+			}
+			if err := c.writeEvent(event); err != nil {
+				return
+			}
+			if event.terminal() {
+				c.close()
+				return
+			}
+		}
+	}
+}
+
+func (c *unixPCMConn) writeEvent(event localCallEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	return c.writeFrame(unixFrameControlEvent, payload)
+}
+
+func (c *unixPCMConn) writeFrame(frameType byte, payload []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	return writeUnixFrame(c.conn, frameType, payload)
+}
+
+func (c *unixPCMConn) close() {
+	c.closeMu.Do(func() { _ = c.conn.Close() })
+}
+
+func validateStartCommand(callID, destination string, sampleRate, channels int) error {
+	if !validLocalCallID(callID) {
+		return errors.New("call_id must contain 1 to 128 safe ASCII characters")
+	}
+	if sampleRate != unixPCMRate || channels != unixPCMChannels {
+		return fmt.Errorf("PCM format must be mono 16 kHz")
+	}
+	if !validE164(destination) {
+		return errors.New("destination must be E.164")
+	}
+	return nil
+}
+
+func validLocalCallID(callID string) bool {
+	if len(callID) == 0 || len(callID) > 128 {
+		return false
+	}
+	for _, r := range callID {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '-', '_', '.', ':':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validE164(destination string) bool {
+	if len(destination) < 9 || len(destination) > 16 || destination[0] != '+' {
+		return false
+	}
+	for _, r := range destination[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return destination[1] != '0'
+}
+
+func validatePCM(payload []byte, maximum int) error {
+	if len(payload) == 0 || len(payload)%2 != 0 {
+		return errors.New("PCM16 payload must be non-empty and even-sized")
+	}
+	if len(payload) > maximum {
+		return fmt.Errorf("PCM16 payload exceeds %d bytes", maximum)
+	}
+	return nil
+}
+
+func readUnixFrame(reader io.Reader) (byte, []byte, error) {
+	header := make([]byte, 5)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return 0, nil, err
+	}
+	length := binary.BigEndian.Uint32(header[1:])
+	if length > unixMaxFrameSize {
+		return 0, nil, fmt.Errorf("local PCM frame size %d exceeds maximum", length)
+	}
+	payload := make([]byte, int(length))
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return 0, nil, err
+	}
+	return header[0], payload, nil
+}
+
+func writeUnixFrame(writer io.Writer, frameType byte, payload []byte) error {
+	if len(payload) > unixMaxFrameSize {
+		return fmt.Errorf("local PCM frame exceeds %d bytes", unixMaxFrameSize)
+	}
+	header := make([]byte, 5)
+	header[0] = frameType
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+	if err := writeAll(writer, header); err != nil {
+		return err
+	}
+	return writeAll(writer, payload)
+}
+
+func writeAll(writer io.Writer, payload []byte) error {
+	for len(payload) > 0 {
+		n, err := writer.Write(payload)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		payload = payload[n:]
+	}
+	return nil
+}
+
+type sessionLocalBackend struct {
+	sessions *SessionManager
+}
+
+func (b sessionLocalBackend) StartOutbound(ctx context.Context, externalCallID, destination string) (localPCMCall, error) {
+	session, err := b.sessions.singleReadySession()
+	if err != nil {
+		return nil, err
+	}
+	if b.sessions.activeCallCount() != 0 {
+		return nil, errors.New("another WhatsApp call is active")
+	}
+	peer := types.NewJID(normalizePhone(destination), types.DefaultUserServer)
+	managed := newManagedLocalCall(externalCallID)
+	managed.emit(localCallEvent{Event: "dialing"})
+	if _, err := session.startLocalOutgoing(ctx, peer, managed); err != nil {
+		managed.closed()
+		return nil, err
+	}
+	if !managed.isBound() {
+		managed.closed()
+		return nil, errors.New("local call media was not bound")
+	}
+	return managed, nil
+}
+
+func (m *SessionManager) singleReadySession() (*Session, error) {
+	m.mu.RLock()
+	ordered := make([]*Session, 0, len(m.order))
+	for _, id := range m.order {
+		if session := m.sessions[id]; session != nil {
+			ordered = append(ordered, session)
+		}
+	}
+	m.mu.RUnlock()
+
+	ready := make([]*Session, 0, 1)
+	for _, session := range ordered {
+		info := session.info()
+		if info.Paired && info.State == "open" {
+			ready = append(ready, session)
+		}
+	}
+	if len(ready) == 0 {
+		return nil, errors.New("no paired WhatsApp session is ready")
+	}
+	if len(ready) != 1 {
+		return nil, errors.New("exactly one paired WhatsApp session is required")
+	}
+	return ready[0], nil
+}
+
+func (m *SessionManager) activeCallCount() int {
+	m.mu.RLock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		sessions = append(sessions, session)
+	}
+	m.mu.RUnlock()
+	total := 0
+	for _, session := range sessions {
+		total += session.callCount()
+	}
+	return total
+}
+
+type localCallObserver interface {
+	bound(*Session, string, localCallMedia)
+	onPeerPCM([]float32)
+	onState(*call.CallInfo)
+	closed()
+}
+
+type localCallMedia interface {
+	FeedCapturedPCM([]float32)
+	FlushCapturedPCM()
+	WaitCapturedPCMDrained(context.Context) error
+	EndCall(context.Context, core.EndCallReason) error
+}
+
+type managedLocalCall struct {
+	externalCallID string
+	pcm            chan []byte
+	events         chan localCallEvent
+
+	mu           sync.Mutex
+	media        localCallMedia
+	playback     *pcmPlayback
+	fallbackDone <-chan struct{}
+	lastEvent    string
+	terminal     bool
+	endStarted   bool
+	backpressure bool
+}
+
+func newManagedLocalCall(externalCallID string) *managedLocalCall {
+	return &managedLocalCall{
+		externalCallID: externalCallID,
+		pcm:            make(chan []byte, 32),
+		events:         make(chan localCallEvent, 16),
+	}
+}
+
+func (m *managedLocalCall) bound(_ *Session, _ string, mediaCall localCallMedia) {
+	m.mu.Lock()
+	m.media = mediaCall
+	m.playback = newPCMPlayback(mediaCall.FeedCapturedPCM, mediaCall.FlushCapturedPCM)
+	m.mu.Unlock()
+}
+
+func (m *managedLocalCall) isBound() bool {
+	m.mu.Lock()
+	bound := m.media != nil && m.playback != nil
+	m.mu.Unlock()
+	return bound
+}
+
+func (m *managedLocalCall) InboundPCM() <-chan []byte     { return m.pcm }
+func (m *managedLocalCall) Events() <-chan localCallEvent { return m.events }
+
+func (m *managedLocalCall) SendPCM(payload []byte) error {
+	if err := validatePCM(payload, unixMaxFrameSize); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	playback := m.playback
+	m.mu.Unlock()
+	if playback == nil {
+		return errors.New("call media is not ready")
+	}
+	_, err := playback.Enqueue(payload, false)
+	return err
+}
+
+func (m *managedLocalCall) PlayFallback(payload []byte) error {
+	if err := validatePCM(payload, unixMaxFallbackBytes); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	playback := m.playback
+	m.mu.Unlock()
+	if playback == nil {
+		return errors.New("call media is not ready")
+	}
+	playback.Flush()
+	padded := padPCM(payload, unixCodecFrameBytes)
+	done, err := playback.Enqueue(padded, true)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.fallbackDone = done
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *managedLocalCall) FlushPlayback() error {
+	m.mu.Lock()
+	playback := m.playback
+	m.fallbackDone = nil
+	m.mu.Unlock()
+	if playback == nil {
+		return errors.New("call media is not ready")
+	}
+	playback.Flush()
+	return nil
+}
+
+func (m *managedLocalCall) End(_ context.Context, reason string) error {
+	m.mu.Lock()
+	if m.endStarted {
+		m.mu.Unlock()
+		return nil
+	}
+	m.endStarted = true
+	mediaCall := m.media
+	playback := m.playback
+	fallbackDone := m.fallbackDone
+	m.mu.Unlock()
+	if mediaCall == nil {
+		return errors.New("call media is not ready")
+	}
+
+	var drainErr error
+	if fallbackDone != nil {
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5250*time.Millisecond)
+		select {
+		case <-fallbackDone:
+			drainErr = mediaCall.WaitCapturedPCMDrained(drainCtx)
+		case <-drainCtx.Done():
+			drainErr = drainCtx.Err()
+		}
+		cancel()
+	}
+	endCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	endErr := mediaCall.EndCall(endCtx, mapLocalEndReason(reason))
+	cancel()
+	if playback != nil {
+		playback.Close()
+	}
+	if drainErr != nil {
+		return fmt.Errorf("drain fallback PCM: %w", drainErr)
+	}
+	return endErr
+}
+
+func (m *managedLocalCall) onPeerPCM(pcm []float32) {
+	payload := media.PCMFloat32ToInt16LE(pcm)
+	if len(payload) == 0 {
+		return
+	}
+	select {
+	case m.pcm <- payload:
+	default:
+		m.mu.Lock()
+		alreadyFailed := m.backpressure
+		m.backpressure = true
+		m.mu.Unlock()
+		if !alreadyFailed {
+			m.emit(localCallEvent{Event: "error", Error: "worker PCM backpressure"})
+			go func() { _ = m.End(context.Background(), "worker_pcm_backpressure") }()
+		}
+	}
+}
+
+func (m *managedLocalCall) onState(info *call.CallInfo) {
+	if info == nil {
+		return
+	}
+	event := localCallEvent{}
+	switch info.StateData.State {
+	case core.CallStateInitiating:
+		event.Event = "dialing"
+	case core.CallStateRinging, core.CallStateIncomingRinging, core.CallStateConnecting:
+		event.Event = "ringing"
+	case core.CallStateActive, core.CallStateOnHold:
+		event.Event = "connected"
+	case core.CallStateEnded:
+		event.Reason = string(info.StateData.EndReason)
+		if info.StateData.EndReason == core.EndCallReasonBusy {
+			event.Event = "busy"
+		} else {
+			event.Event = "ended"
+		}
+	default:
+		return
+	}
+	m.emit(event)
+	if event.terminal() {
+		m.closed()
+	}
+}
+
+func (m *managedLocalCall) emit(event localCallEvent) {
+	event.CallID = m.externalCallID
+	m.mu.Lock()
+	if m.terminal || event.Event == m.lastEvent {
+		m.mu.Unlock()
+		return
+	}
+	m.lastEvent = event.Event
+	if event.terminal() {
+		m.terminal = true
+	}
+	m.mu.Unlock()
+	select {
+	case m.events <- event:
+	default:
+		go func() { _ = m.End(context.Background(), "worker_event_backpressure") }()
+	}
+}
+
+func (m *managedLocalCall) closed() {
+	m.mu.Lock()
+	playback := m.playback
+	m.mu.Unlock()
+	if playback != nil {
+		playback.Close()
+	}
+}
+
+func mapLocalEndReason(reason string) core.EndCallReason {
+	lower := strings.ToLower(reason)
+	switch {
+	case strings.Contains(lower, "cancel"):
+		return core.EndCallReasonCancelled
+	case strings.Contains(lower, "timeout"), strings.Contains(lower, "duration"):
+		return core.EndCallReasonTimeout
+	case strings.Contains(lower, "busy"):
+		return core.EndCallReasonBusy
+	case strings.Contains(lower, "fail"), strings.Contains(lower, "error"), strings.Contains(lower, "unavailable"):
+		return core.EndCallReasonFailed
+	default:
+		return core.EndCallReasonUserEnded
+	}
+}
+
+func padPCM(payload []byte, multiple int) []byte {
+	length := len(payload)
+	paddedLength := ((length + multiple - 1) / multiple) * multiple
+	padded := make([]byte, paddedLength)
+	copy(padded, payload)
+	return padded
+}
+
+type playbackSegment struct {
+	data []byte
+	done chan struct{}
+}
+
+type pcmPlayback struct {
+	feed     func([]float32)
+	flush    func()
+	interval time.Duration
+	chunk    int
+	maximum  int
+
+	actionMu sync.Mutex
+	mu       sync.Mutex
+	segments []playbackSegment
+	queued   int
+	closed   bool
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+func newPCMPlayback(feed func([]float32), flush func()) *pcmPlayback {
+	p := &pcmPlayback{
+		feed: feed, flush: flush, interval: 20 * time.Millisecond,
+		chunk: unixPCMChunkBytes, maximum: unixMaxPlaybackBytes, stop: make(chan struct{}),
+	}
+	go p.run()
+	return p
+}
+
+func (p *pcmPlayback) Enqueue(payload []byte, fallback bool) (<-chan struct{}, error) {
+	if err := validatePCM(payload, p.maximum); err != nil {
+		return nil, err
+	}
+	copyPayload := append([]byte(nil), payload...)
+	var done chan struct{}
+	if fallback {
+		done = make(chan struct{})
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil, net.ErrClosed
+	}
+	if p.queued+len(copyPayload) > p.maximum {
+		p.mu.Unlock()
+		return nil, errors.New("PCM playback queue is full")
+	}
+	p.segments = append(p.segments, playbackSegment{data: copyPayload, done: done})
+	p.queued += len(copyPayload)
+	p.mu.Unlock()
+	if fallback {
+		p.pumpOnce()
+	}
+	return done, nil
+}
+
+func (p *pcmPlayback) Flush() {
+	p.actionMu.Lock()
+	p.mu.Lock()
+	p.discardLocked()
+	p.mu.Unlock()
+	p.flush()
+	p.actionMu.Unlock()
+}
+
+func (p *pcmPlayback) Close() {
+	p.stopOnce.Do(func() {
+		p.actionMu.Lock()
+		p.mu.Lock()
+		p.closed = true
+		p.discardLocked()
+		p.mu.Unlock()
+		p.flush()
+		close(p.stop)
+		p.actionMu.Unlock()
+	})
+}
+
+func (p *pcmPlayback) run() {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.pumpOnce()
+		case <-p.stop:
+			return
+		}
+	}
+}
+
+func (p *pcmPlayback) pumpOnce() {
+	p.actionMu.Lock()
+	defer p.actionMu.Unlock()
+	p.mu.Lock()
+	if p.closed || len(p.segments) == 0 {
+		p.mu.Unlock()
+		return
+	}
+	payload := make([]byte, 0, p.chunk)
+	completed := make([]chan struct{}, 0, 1)
+	for len(payload) < p.chunk && len(p.segments) > 0 {
+		segment := &p.segments[0]
+		n := p.chunk - len(payload)
+		if len(segment.data) < n {
+			n = len(segment.data)
+		}
+		payload = append(payload, segment.data[:n]...)
+		segment.data = segment.data[n:]
+		p.queued -= n
+		if len(segment.data) == 0 {
+			if segment.done != nil {
+				completed = append(completed, segment.done)
+			}
+			p.segments = p.segments[1:]
+		}
+	}
+	p.mu.Unlock()
+	p.feed(media.PCMInt16LEToFloat32(payload))
+	for _, done := range completed {
+		close(done)
+	}
+}
+
+func (p *pcmPlayback) discardLocked() {
+	for _, segment := range p.segments {
+		if segment.done != nil {
+			close(segment.done)
+		}
+	}
+	p.segments = nil
+	p.queued = 0
+}

--- a/internal/app/unixbridge_test.go
+++ b/internal/app/unixbridge_test.go
@@ -1,0 +1,549 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"wacalls/internal/voip/call"
+	"wacalls/internal/voip/core"
+)
+
+type fakeLocalStart struct {
+	callID string
+	to     string
+	call   *fakeLocalCall
+}
+
+type fakeLocalBackend struct {
+	starts chan fakeLocalStart
+	err    error
+}
+
+func newFakeLocalBackend() *fakeLocalBackend {
+	return &fakeLocalBackend{starts: make(chan fakeLocalStart, 8)}
+}
+
+func (f *fakeLocalBackend) StartOutbound(_ context.Context, callID, to string) (localPCMCall, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	localCall := newFakeLocalCall()
+	f.starts <- fakeLocalStart{callID: callID, to: to, call: localCall}
+	return localCall, nil
+}
+
+type fakeLocalCall struct {
+	inbound  chan []byte
+	events   chan localCallEvent
+	sent     chan []byte
+	fallback chan []byte
+	flushes  chan struct{}
+	ends     chan string
+}
+
+func newFakeLocalCall() *fakeLocalCall {
+	return &fakeLocalCall{
+		inbound: make(chan []byte, 4), events: make(chan localCallEvent, 4),
+		sent: make(chan []byte, 4), fallback: make(chan []byte, 4),
+		flushes: make(chan struct{}, 4), ends: make(chan string, 4),
+	}
+}
+
+func (f *fakeLocalCall) InboundPCM() <-chan []byte     { return f.inbound }
+func (f *fakeLocalCall) Events() <-chan localCallEvent { return f.events }
+func (f *fakeLocalCall) SendPCM(payload []byte) error {
+	f.sent <- append([]byte(nil), payload...)
+	return nil
+}
+func (f *fakeLocalCall) PlayFallback(payload []byte) error {
+	f.fallback <- append([]byte(nil), payload...)
+	return nil
+}
+func (f *fakeLocalCall) FlushPlayback() error {
+	f.flushes <- struct{}{}
+	return nil
+}
+func (f *fakeLocalCall) End(_ context.Context, reason string) error {
+	f.ends <- reason
+	return nil
+}
+
+func TestUnixPCMServerEndToEndProtocolAndPermissions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backend := newFakeLocalBackend()
+	dir := filepath.Join(shortTempDir(t), "ligacao-ai")
+	socketPath := filepath.Join(dir, "wacalls.sock")
+	server := newUnixPCMServer(socketPath, backend, slog.Default())
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	assertPerm(t, dir, 0o750)
+	assertPerm(t, socketPath, 0o660)
+	info, err := os.Lstat(socketPath)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("expected Unix socket, info=%v err=%v", info, err)
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	writeControlForTest(t, conn, map[string]any{
+		"op": "start", "call_id": "call-123", "to": "+5511999999999",
+		"sample_rate": 16000, "channels": 1,
+	})
+	started := awaitValue(t, backend.starts)
+	if started.callID != "call-123" || started.to != "+5511999999999" {
+		t.Fatalf("unexpected start: %+v", started)
+	}
+
+	started.call.events <- localCallEvent{Event: "ringing"}
+	event := readEventForTest(t, conn)
+	if event.Event != "ringing" || event.CallID != "call-123" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	started.call.inbound <- []byte{1, 0, 2, 0}
+	kind, payload, err := readUnixFrame(conn)
+	if err != nil {
+		t.Fatalf("read inbound PCM: %v", err)
+	}
+	if kind != unixFrameInboundPCM || string(payload) != string([]byte{1, 0, 2, 0}) {
+		t.Fatalf("unexpected inbound PCM kind=%x payload=%v", kind, payload)
+	}
+
+	if err := writeUnixFrame(conn, unixFrameOutboundPCM, []byte{3, 0, 4, 0}); err != nil {
+		t.Fatalf("write outbound PCM: %v", err)
+	}
+	if got := awaitValue(t, started.call.sent); string(got) != string([]byte{3, 0, 4, 0}) {
+		t.Fatalf("outbound PCM=%v", got)
+	}
+	writeControlForTest(t, conn, map[string]any{"op": "flush_playback"})
+	awaitValue(t, started.call.flushes)
+	if err := writeUnixFrame(conn, unixFrameFallbackPCM, []byte{5, 0, 6, 0}); err != nil {
+		t.Fatalf("write fallback PCM: %v", err)
+	}
+	if got := awaitValue(t, started.call.fallback); string(got) != string([]byte{5, 0, 6, 0}) {
+		t.Fatalf("fallback PCM=%v", got)
+	}
+	writeControlForTest(t, conn, map[string]any{"op": "end", "reason": "test_complete"})
+	if got := awaitValue(t, started.call.ends); got != "test_complete" {
+		t.Fatalf("end reason=%q", got)
+	}
+}
+
+func TestUnixPCMServerRejectsSecondActiveSessionAndReleasesCapacity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backend := newFakeLocalBackend()
+	socketPath := filepath.Join(shortTempDir(t), "run", "wacalls.sock")
+	server := newUnixPCMServer(socketPath, backend, slog.Default())
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	first := dialUnixForTest(t, socketPath)
+	writeStartForTest(t, first, "call-1")
+	firstStart := awaitValue(t, backend.starts)
+
+	second := dialUnixForTest(t, socketPath)
+	writeStartForTest(t, second, "call-2")
+	busy := readEventForTest(t, second)
+	if busy.Event != "busy" || busy.Reason != "capacity" || busy.CallID != "call-2" {
+		t.Fatalf("unexpected busy event: %+v", busy)
+	}
+	_ = second.Close()
+	select {
+	case unexpected := <-backend.starts:
+		t.Fatalf("second active call reached backend: %+v", unexpected)
+	default:
+	}
+
+	writeControlForTest(t, first, map[string]any{"op": "end", "reason": "finished"})
+	awaitValue(t, firstStart.call.ends)
+	_ = first.SetReadDeadline(time.Now().Add(time.Second))
+	_, _, _ = readUnixFrame(first)
+	_ = first.Close()
+
+	third := dialUnixForTest(t, socketPath)
+	defer third.Close()
+	writeStartForTest(t, third, "call-3")
+	thirdStart := awaitValue(t, backend.starts)
+	if thirdStart.callID != "call-3" {
+		t.Fatalf("capacity was not released: %+v", thirdStart)
+	}
+}
+
+func TestUnixPCMServerRejectsInvalidStartWithoutCallingBackend(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backend := newFakeLocalBackend()
+	socketPath := filepath.Join(shortTempDir(t), "run", "wacalls.sock")
+	server := newUnixPCMServer(socketPath, backend, slog.Default())
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	conn := dialUnixForTest(t, socketPath)
+	defer conn.Close()
+	writeControlForTest(t, conn, map[string]any{
+		"op": "start", "call_id": "bad", "to": "5511999999999",
+		"sample_rate": 44100, "channels": 2,
+	})
+	event := readEventForTest(t, conn)
+	if event.Event != "error" || event.Error == "" {
+		t.Fatalf("unexpected error event: %+v", event)
+	}
+	select {
+	case unexpected := <-backend.starts:
+		t.Fatalf("invalid start reached backend: %+v", unexpected)
+	default:
+	}
+}
+
+func TestValidateStartCommandRejectsUnsafeCallID(t *testing.T) {
+	for _, callID := range []string{"", "call id", "call\nlog", "chamada/1"} {
+		if err := validateStartCommand(callID, "+5511999999999", 16000, 1); err == nil {
+			t.Fatalf("unsafe call ID %q was accepted", callID)
+		}
+	}
+	if err := validateStartCommand("call_123.v1:attempt-2", "+5511999999999", 16000, 1); err != nil {
+		t.Fatalf("safe call ID rejected: %v", err)
+	}
+}
+
+func TestUnixPCMServerClosesAfterRemoteTerminalEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backend := newFakeLocalBackend()
+	socketPath := filepath.Join(shortTempDir(t), "run", "wacalls.sock")
+	server := newUnixPCMServer(socketPath, backend, slog.Default())
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	conn := dialUnixForTest(t, socketPath)
+	defer conn.Close()
+	writeStartForTest(t, conn, "call-busy")
+	started := awaitValue(t, backend.starts)
+	started.call.events <- localCallEvent{Event: "busy", Reason: "busy"}
+	event := readEventForTest(t, conn)
+	if event.Event != "busy" || event.CallID != "call-busy" {
+		t.Fatalf("unexpected terminal event: %+v", event)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, _, err := readUnixFrame(conn)
+	if err == nil {
+		t.Fatal("terminal event did not close Unix connection")
+	}
+	if reason := awaitValue(t, started.call.ends); reason != "worker_disconnected" {
+		t.Fatalf("terminal cleanup reason=%q", reason)
+	}
+}
+
+func TestUnixPCMServerRefusesToReplaceRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run", "wacalls.sock")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("do not replace"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := newUnixPCMServer(path, newFakeLocalBackend(), slog.Default())
+	if err := server.Start(context.Background()); err == nil {
+		t.Fatal("expected regular socket path to be rejected")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "do not replace" {
+		t.Fatalf("regular file was changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestUnixPCMServerRefusesInsecureExistingDirectoryWithoutChangingIt(t *testing.T) {
+	dir := filepath.Join(shortTempDir(t), "insecure")
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	server := newUnixPCMServer(filepath.Join(dir, "wacalls.sock"), newFakeLocalBackend(), slog.Default())
+	if err := server.Start(context.Background()); err == nil {
+		t.Fatal("expected insecure socket directory to be rejected")
+	}
+	assertPerm(t, dir, 0o777)
+}
+
+type fakeLocalMedia struct {
+	mu           sync.Mutex
+	feeds        chan []float32
+	flushes      int
+	drainStarted chan struct{}
+	drainRelease chan struct{}
+	ends         chan core.EndCallReason
+}
+
+func newFakeLocalMedia() *fakeLocalMedia {
+	return &fakeLocalMedia{
+		feeds: make(chan []float32, 8), drainStarted: make(chan struct{}, 1),
+		drainRelease: make(chan struct{}), ends: make(chan core.EndCallReason, 1),
+	}
+}
+
+func (f *fakeLocalMedia) FeedCapturedPCM(pcm []float32) {
+	f.feeds <- append([]float32(nil), pcm...)
+}
+func (f *fakeLocalMedia) FlushCapturedPCM() {
+	f.mu.Lock()
+	f.flushes++
+	f.mu.Unlock()
+}
+func (f *fakeLocalMedia) WaitCapturedPCMDrained(ctx context.Context) error {
+	f.drainStarted <- struct{}{}
+	select {
+	case <-f.drainRelease:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (f *fakeLocalMedia) EndCall(_ context.Context, reason core.EndCallReason) error {
+	f.ends <- reason
+	return nil
+}
+
+func TestManagedLocalCallPlaysFullFallbackBeforeEnding(t *testing.T) {
+	mediaCall := newFakeLocalMedia()
+	managed := newManagedLocalCall("call-fallback")
+	managed.bound(nil, "internal", mediaCall)
+	defer managed.closed()
+
+	if err := managed.PlayFallback([]byte{1, 0, 2, 0}); err != nil {
+		t.Fatalf("PlayFallback: %v", err)
+	}
+	managed.mu.Lock()
+	playback := managed.playback
+	managed.mu.Unlock()
+	// The fallback is padded to one 60 ms codec frame and paced as three 20 ms
+	// chunks. Enqueue sends the first chunk immediately.
+	first := awaitValue(t, mediaCall.feeds)
+	playback.pumpOnce()
+	second := awaitValue(t, mediaCall.feeds)
+	playback.pumpOnce()
+	third := awaitValue(t, mediaCall.feeds)
+	if len(first)+len(second)+len(third) != unixCodecFrameBytes/2 {
+		t.Fatalf("fallback samples=%d, want %d", len(first)+len(second)+len(third), unixCodecFrameBytes/2)
+	}
+
+	endResult := make(chan error, 1)
+	go func() { endResult <- managed.End(context.Background(), "agent_error") }()
+	awaitValue(t, mediaCall.drainStarted)
+	select {
+	case reason := <-mediaCall.ends:
+		t.Fatalf("call ended before PCM drained: %s", reason)
+	default:
+	}
+	close(mediaCall.drainRelease)
+	if reason := awaitValue(t, mediaCall.ends); reason != core.EndCallReasonFailed {
+		t.Fatalf("mapped end reason=%q", reason)
+	}
+	if err := awaitValue(t, endResult); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+	mediaCall.mu.Lock()
+	flushes := mediaCall.flushes
+	mediaCall.mu.Unlock()
+	if flushes == 0 {
+		t.Fatal("fallback did not clear stale playback first")
+	}
+}
+
+func TestManagedLocalCallFlushDropsQueuedAgentAudio(t *testing.T) {
+	mediaCall := newFakeLocalMedia()
+	managed := newManagedLocalCall("call-flush")
+	managed.bound(nil, "internal", mediaCall)
+	defer managed.closed()
+
+	if err := managed.SendPCM(make([]byte, unixPCMChunkBytes*2)); err != nil {
+		t.Fatalf("SendPCM: %v", err)
+	}
+	if err := managed.FlushPlayback(); err != nil {
+		t.Fatalf("FlushPlayback: %v", err)
+	}
+	managed.mu.Lock()
+	playback := managed.playback
+	managed.mu.Unlock()
+	playback.pumpOnce()
+	select {
+	case frame := <-mediaCall.feeds:
+		t.Fatalf("flushed PCM was still played: %d samples", len(frame))
+	default:
+	}
+	mediaCall.mu.Lock()
+	flushes := mediaCall.flushes
+	mediaCall.mu.Unlock()
+	if flushes != 1 {
+		t.Fatalf("media flushes=%d, want 1", flushes)
+	}
+}
+
+func TestManagedLocalCallMapsAndDeduplicatesStateEvents(t *testing.T) {
+	managed := newManagedLocalCall("external-call")
+	managed.onState(&call.CallInfo{StateData: call.CallStateData{State: core.CallStateRinging}})
+	managed.onState(&call.CallInfo{StateData: call.CallStateData{State: core.CallStateRinging}})
+	managed.onState(&call.CallInfo{StateData: call.CallStateData{State: core.CallStateEnded, EndReason: core.EndCallReasonBusy}})
+
+	first := awaitValue(t, managed.events)
+	second := awaitValue(t, managed.events)
+	if first.Event != "ringing" || second.Event != "busy" || second.CallID != "external-call" {
+		t.Fatalf("unexpected events: first=%+v second=%+v", first, second)
+	}
+	select {
+	case extra := <-managed.events:
+		t.Fatalf("duplicate event emitted: %+v", extra)
+	default:
+	}
+}
+
+func TestReadUnixFrameRejectsOversizedPayloadBeforeAllocation(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	done := make(chan error, 1)
+	go func() {
+		header := []byte{unixFrameOutboundPCM, 0, 0x10, 0, 1}
+		_, err := client.Write(header)
+		done <- err
+	}()
+	_, _, err := readUnixFrame(server)
+	if err == nil {
+		t.Fatal("oversized frame was accepted")
+	}
+	if writeErr := awaitValue(t, done); writeErr != nil {
+		t.Fatalf("write header: %v", writeErr)
+	}
+}
+
+func assertPerm(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("permissions %s=%#o, want %#o", path, got, want)
+	}
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "wc-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func dialUnixForTest(t *testing.T, path string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	return conn
+}
+
+func writeStartForTest(t *testing.T, conn net.Conn, callID string) {
+	t.Helper()
+	writeControlForTest(t, conn, map[string]any{
+		"op": "start", "call_id": callID, "to": "+5511999999999",
+		"sample_rate": 16000, "channels": 1,
+	})
+}
+
+func writeControlForTest(t *testing.T, conn net.Conn, command map[string]any) {
+	t.Helper()
+	payload, err := json.Marshal(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeUnixFrame(conn, unixFrameControlRequest, payload); err != nil {
+		t.Fatalf("write control: %v", err)
+	}
+}
+
+func readEventForTest(t *testing.T, conn net.Conn) localCallEvent {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	kind, payload, err := readUnixFrame(conn)
+	if err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	if kind != unixFrameControlEvent {
+		t.Fatalf("frame kind=%x, want event", kind)
+	}
+	var event localCallEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	return event
+}
+
+func awaitValue[T any](t *testing.T, channel <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for test signal")
+		var zero T
+		return zero
+	}
+}
+
+func TestWriteAllHandlesShortWrites(t *testing.T) {
+	writer := &shortWriter{maximum: 2}
+	if err := writeAll(writer, []byte("abcdef")); err != nil {
+		t.Fatalf("writeAll: %v", err)
+	}
+	if string(writer.data) != "abcdef" || writer.writes < 3 {
+		t.Fatalf("short writes not handled: data=%q writes=%d", writer.data, writer.writes)
+	}
+}
+
+type shortWriter struct {
+	maximum int
+	data    []byte
+	writes  int
+}
+
+func (w *shortWriter) Write(payload []byte) (int, error) {
+	if len(payload) == 0 {
+		return 0, errors.New("empty write")
+	}
+	n := w.maximum
+	if len(payload) < n {
+		n = len(payload)
+	}
+	w.data = append(w.data, payload[:n]...)
+	w.writes++
+	return n, nil
+}
+
+var _ io.Writer = (*shortWriter)(nil)

--- a/internal/voip/call/callmanager_media.go
+++ b/internal/voip/call/callmanager_media.go
@@ -1,6 +1,8 @@
 package call
 
 import (
+	"context"
+
 	"wacalls/internal/voip/core"
 	"wacalls/internal/voip/engine"
 	"wacalls/internal/voip/media"
@@ -23,6 +25,25 @@ func (m *CallManager) FeedCapturedPCM(data []float32) {
 	if a, ok := engine.Capability[core.AudioSink](m.extensions); ok {
 		a.FeedPCM(data)
 	}
+}
+
+// FlushCapturedPCM discards audio that has not yet been sent to the peer. The
+// audio extension also invalidates a frame currently being encoded, so no
+// stale TTS frame can be emitted after this method returns.
+func (m *CallManager) FlushCapturedPCM() {
+	if a, ok := engine.Capability[core.AudioSink](m.extensions); ok {
+		a.FlushPCM()
+	}
+}
+
+// WaitCapturedPCMDrained waits until every queued captured sample has been
+// encoded and handed to the relay. It is used by the local fallback path to
+// avoid tearing down the call before the warning has played.
+func (m *CallManager) WaitCapturedPCMDrained(ctx context.Context) error {
+	if a, ok := engine.Capability[core.AudioSink](m.extensions); ok {
+		return a.WaitPCMDrained(ctx)
+	}
+	return nil
 }
 
 func (m *CallManager) registerRTPHandler(pt uint8, handler func(*media.RtpPacket)) {

--- a/internal/voip/call/client.go
+++ b/internal/voip/call/client.go
@@ -77,8 +77,23 @@ func (c *Client) Drain() []*CallManager {
 }
 
 func (c *Client) StartCall(ctx context.Context, peer types.JID, isVideo bool) (string, error) {
+	return c.startCall(ctx, peer, isVideo, nil)
+}
+
+// StartCallWithSetup lets a transport adapter attach to the CallManager after
+// the standard callbacks are wired but before the first state transition can
+// fire. Keeping this hook inside call creation avoids a pending-adapter race
+// with unrelated inbound calls.
+func (c *Client) StartCallWithSetup(ctx context.Context, peer types.JID, isVideo bool, setup func(string, *CallManager)) (string, error) {
+	return c.startCall(ctx, peer, isVideo, setup)
+}
+
+func (c *Client) startCall(ctx context.Context, peer types.JID, isVideo bool, setup func(string, *CallManager)) (string, error) {
 	callID := signaling.GenerateCallID()
 	cm := c.createCall(callID)
+	if setup != nil {
+		setup(callID, cm)
+	}
 	if err := cm.StartCall(ctx, callID, peer, isVideo); err != nil {
 		c.Remove(callID)
 		return "", err

--- a/internal/voip/core/ports.go
+++ b/internal/voip/core/ports.go
@@ -17,6 +17,8 @@ type VideoCodec interface {
 
 type AudioSink interface {
 	FeedPCM(pcm []float32)
+	FlushPCM()
+	WaitPCMDrained(ctx context.Context) error
 	OnPeerPCM(handler func(pcm []float32))
 }
 

--- a/internal/voip/extension/audio/audio.go
+++ b/internal/voip/extension/audio/audio.go
@@ -18,6 +18,9 @@ type Audio struct {
 	scope              *engine.CallScope
 	mu                 sync.Mutex
 	captureBuf         []float32
+	captureGeneration  uint64
+	captureInFlight    bool
+	drainCh            chan struct{}
 	audioTimelineSet   bool
 	audioBaseTs        uint32
 	audioPlayedSamples uint64
@@ -27,7 +30,9 @@ type Audio struct {
 }
 
 func New(codec core.AudioCodec) *Audio {
-	return &Audio{codec: codec}
+	drained := make(chan struct{})
+	close(drained)
+	return &Audio{codec: codec, drainCh: drained}
 }
 
 func (a *Audio) Name() string {
@@ -55,6 +60,10 @@ func (a *Audio) Detach() {
 		close(a.sendLoopStop)
 		a.sendLoopStop = nil
 	}
+	a.captureGeneration++
+	a.captureBuf = nil
+	a.captureInFlight = false
+	a.markCaptureDrainedLocked()
 	scope := a.scope
 	a.mu.Unlock()
 	if scope != nil {
@@ -69,9 +78,56 @@ func (a *Audio) FeedPCM(pcm []float32) {
 	if a.codec == nil || len(pcm) == 0 {
 		return
 	}
+	a.markCapturePendingLocked()
 	a.captureBuf = append(a.captureBuf, pcm...)
 	if maxBuffered := a.codec.FrameSize() * 4; len(a.captureBuf) > maxBuffered {
 		a.captureBuf = a.captureBuf[len(a.captureBuf)-maxBuffered:]
+	}
+}
+
+// FlushPCM atomically invalidates all captured audio that has not yet reached
+// the relay. Incrementing the generation also cancels a frame being encoded
+// outside the lock, which is required for immediate barge-in semantics.
+func (a *Audio) FlushPCM() {
+	a.mu.Lock()
+	a.captureGeneration++
+	a.captureBuf = nil
+	if !a.captureInFlight {
+		a.markCaptureDrainedLocked()
+	}
+	a.mu.Unlock()
+}
+
+func (a *Audio) WaitPCMDrained(ctx context.Context) error {
+	a.mu.Lock()
+	if len(a.captureBuf) == 0 && !a.captureInFlight {
+		a.mu.Unlock()
+		return nil
+	}
+	ch := a.drainCh
+	a.mu.Unlock()
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (a *Audio) markCapturePendingLocked() {
+	select {
+	case <-a.drainCh:
+		a.drainCh = make(chan struct{})
+	default:
+	}
+}
+
+func (a *Audio) markCaptureDrainedLocked() {
+	select {
+	case <-a.drainCh:
+	default:
+		close(a.drainCh)
 	}
 }
 
@@ -109,16 +165,42 @@ func (a *Audio) startSendLoopLocked() {
 				continue
 			}
 			frame := silence
+			voicedFrame := false
+			generation := a.captureGeneration
 			if len(a.captureBuf) >= frameSize {
 				copy(voiced, a.captureBuf[:frameSize])
 				frame = voiced
 				a.captureBuf = a.captureBuf[frameSize:]
+				a.captureInFlight = true
+				voicedFrame = true
 			}
 			scope := a.scope
 			codec := a.codec
 			a.mu.Unlock()
-			if enc, err := codec.Encode(frame); err == nil {
-				scope.SendAudioFrame(enc, codec.FrameSize())
+
+			enc, err := codec.Encode(frame)
+			if voicedFrame {
+				a.mu.Lock()
+				if generation != a.captureGeneration {
+					a.captureInFlight = false
+					if len(a.captureBuf) == 0 {
+						a.markCaptureDrainedLocked()
+					}
+					a.mu.Unlock()
+					continue
+				}
+				if err == nil {
+					_ = scope.SendAudioFrame(enc, codec.FrameSize())
+				}
+				a.captureInFlight = false
+				if len(a.captureBuf) == 0 {
+					a.markCaptureDrainedLocked()
+				}
+				a.mu.Unlock()
+				continue
+			}
+			if err == nil {
+				_ = scope.SendAudioFrame(enc, codec.FrameSize())
 			}
 		}
 	}()

--- a/internal/voip/extension/audio/audio_test.go
+++ b/internal/voip/extension/audio/audio_test.go
@@ -1,11 +1,15 @@
 package audio
 
 import (
+	"context"
 	"math"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"wacalls/internal/voip/codec/mlow"
 	"wacalls/internal/voip/core"
+	"wacalls/internal/voip/engine"
 	"wacalls/internal/voip/media"
 )
 
@@ -54,3 +58,90 @@ func TestAudioFeedPCMBounds(t *testing.T) {
 		t.Fatalf("captureBuf=%d exceeds bound %d", len(a.captureBuf), codec.FrameSize()*4)
 	}
 }
+
+func TestAudioFlushClearsCaptureBufferAndUnblocksDrain(t *testing.T) {
+	codec, err := mlow.NewMLowCodec(mlow.DefaultCodecOptions)
+	if err != nil {
+		t.Fatalf("NewMLowCodec: %v", err)
+	}
+	defer codec.Close()
+
+	a := New(codec)
+	a.FeedPCM(make([]float32, codec.FrameSize()))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	drained := make(chan error, 1)
+	go func() { drained <- a.WaitPCMDrained(ctx) }()
+	a.FlushPCM()
+
+	if err := <-drained; err != nil {
+		t.Fatalf("WaitPCMDrained: %v", err)
+	}
+	if len(a.captureBuf) != 0 {
+		t.Fatalf("capture buffer has %d samples after flush", len(a.captureBuf))
+	}
+}
+
+func TestAudioFlushInvalidatesFrameBeingEncoded(t *testing.T) {
+	codec := &blockingAudioCodec{started: make(chan struct{}), release: make(chan struct{})}
+	relay := &toggleRelay{}
+	relay.connected.Store(true)
+	sent := make(chan struct{}, 1)
+	a := New(codec)
+	a.FeedPCM(make([]float32, codec.FrameSize()))
+	if err := a.Attach(&engine.CallScope{
+		CallID: "flush-test", Relay: relay, Observer: core.NopObserver{},
+		SendAudioFrame: func([]byte, int) error {
+			sent <- struct{}{}
+			return nil
+		},
+		OnRTP: func(uint8, func(*media.RtpPacket)) {},
+	}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer a.Detach()
+
+	select {
+	case <-codec.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for encode")
+	}
+	a.FlushPCM()
+	relay.connected.Store(false)
+	close(codec.release)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := a.WaitPCMDrained(ctx); err != nil {
+		t.Fatalf("WaitPCMDrained: %v", err)
+	}
+	select {
+	case <-sent:
+		t.Fatal("flushed in-flight frame was sent")
+	default:
+	}
+}
+
+type blockingAudioCodec struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *blockingAudioCodec) Encode([]float32) ([]byte, error) {
+	close(c.started)
+	<-c.release
+	return []byte{1}, nil
+}
+func (*blockingAudioCodec) Decode([]byte) ([]float32, error) { return nil, nil }
+func (*blockingAudioCodec) FrameSize() int                   { return 960 }
+func (*blockingAudioCodec) SampleRate() int                  { return 16_000 }
+func (*blockingAudioCodec) Close()                           {}
+
+type toggleRelay struct {
+	connected atomic.Bool
+}
+
+func (*toggleRelay) Broadcast([]byte)                  {}
+func (*toggleRelay) BufferedAmount() uint64            { return 0 }
+func (r *toggleRelay) HasConnection() bool             { return r.connected.Load() }
+func (*toggleRelay) SetStreamSsrcs([]uint32, []uint32) {}


### PR DESCRIPTION
## Summary
- adds a private AF_UNIX PCM16k bridge for generic realtime agent providers
- supports outbound start, bidirectional PCM, barge-in flush, fallback drain and terminal events
- enforces a single active local agent session and bounded frames/queues
- adds optional bearer protection and exact same-origin CORS for the existing local HTTP API
- persists no audio and exposes no new HTTP route

## Safety
- socket parent must be a real 0750 directory; socket is 0660
- rejects symlinks/non-socket stale paths, unsafe call IDs and invalid E.164
- `--max-calls-per-session=1` remains the pilot deployment requirement

## Verification
- `go test -race -timeout 60s ./internal/app ./internal/voip/extension/audio`
- `go test ./...`
- `go vet ./...`
- `git diff --check origin/develop...HEAD`

This PR is intentionally provider-neutral. ElevenLabs/OpenClaw composition stays outside WaCalls.