### PR TITLE
Fork-friendly CI, faster Docker build, and self-contained binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
+    tags-ignore: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -20,10 +21,10 @@ jobs:
     env:
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -53,6 +54,24 @@ jobs:
           CGO_ENABLED: "0"
         run: go test -count=1 ./...
 
+  race:
+    name: race
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Race test
+        run: go test -race -count=1 ./internal/voip/...
+
   client:
     name: client
     runs-on: ubuntu-latest
@@ -60,10 +79,10 @@ jobs:
       run:
         working-directory: client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,12 +11,25 @@ permissions:
   packages: write
 
 jobs:
-  image:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v4
+      - id: prep
+        env:
+          platform: ${{ matrix.platform }}
+        run: |
+          echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          echo "platform_pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -29,7 +42,60 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/jotadev66/wacalls
+          images: ${{ steps.prep.outputs.image }}
+
+      - id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ steps.prep.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ steps.prep.outputs.platform_pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - id: prep
+        run: echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.prep.outputs.image }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -37,14 +103,13 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ steps.prep.outputs.image }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${{ steps.prep.outputs.image }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,37 @@ permissions:
   contents: write
 
 jobs:
+  web:
+    name: web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload web dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: web-dist
+          path: client/dist
+
   server:
     name: server (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: web
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: "0"
@@ -25,79 +54,51 @@ jobs:
           - goos: windows
             goarch: amd64
             ext: ".exe"
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Fetch web dist
+        uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: internal/app/webui/dist
 
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          out="wacalls-server-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
+          out="wacalls-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
           go build -trimpath \
             -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" \
             -o "dist/${out}" ./cmd/server
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*
 
-  client:
-    name: client
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: client
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: client/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Package
-        run: tar -czf ../wacalls-client-${GITHUB_REF_NAME}.tar.gz -C dist .
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: client-dist
-          path: wacalls-client-*.tar.gz
-
   release:
     name: release
-    needs: [server, client]
+    needs: [server]
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
+          pattern: server-*
           merge-multiple: true
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: artifacts/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY cmd ./cmd
 COPY internal ./internal
+COPY --from=web /web/dist ./internal/app/webui/dist
 ARG VERSION=docker
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -31,11 +32,10 @@ RUN apk add --no-cache ca-certificates \
     && mkdir -p /data && chown app:app /data
 WORKDIR /app
 COPY --from=build /out/wacalls /usr/local/bin/wacalls
-COPY --from=web /web/dist ./client/dist
 USER app
 EXPOSE 8080
 VOLUME ["/data"]
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -qO- http://127.0.0.1:8080/api/sessions >/dev/null 2>&1 || exit 1
 ENTRYPOINT ["wacalls"]
-CMD ["-addr=:8080", "-db=/data/wacalls.db", "-static=/app/client/dist"]
+CMD ["-addr=:8080", "-db=/data/wacalls.db"]

--- a/internal/app/httpapi.go
+++ b/internal/app/httpapi.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"wacalls/internal/app/webui"
 	"wacalls/internal/voip/core"
 
 	"go.mau.fi/whatsmeow/types"
@@ -38,12 +39,20 @@ func (s *Server) routes() http.Handler {
 		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 	}
 
+	mux.Handle("/", s.uiHandler())
+	return withCORS(mux)
+}
+
+func (s *Server) uiHandler() http.Handler {
 	if s.staticDir != "" {
 		if _, err := os.Stat(s.staticDir); err == nil {
-			mux.Handle("/", http.FileServer(http.Dir(s.staticDir)))
+			return http.FileServer(http.Dir(s.staticDir))
 		}
 	}
-	return withCORS(mux)
+	if sub, err := webui.FS(); err == nil {
+		return http.FileServerFS(sub)
+	}
+	return http.NotFoundHandler()
 }
 
 func withCORS(h http.Handler) http.Handler {

--- a/internal/app/webui/dist/index.html
+++ b/internal/app/webui/dist/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WaCalls</title>
+</head>
+<body>
+<p>WaCalls server is running. The web client was not embedded in this build.</p>
+</body>
+</html>

--- a/internal/app/webui/webui.go
+++ b/internal/app/webui/webui.go
@@ -1,0 +1,13 @@
+package webui
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:dist
+var assets embed.FS
+
+func FS() (fs.FS, error) {
+	return fs.Sub(assets, "dist")
+}


### PR DESCRIPTION
## Why

CI was gated only on `main`, so pushes and PRs on `develop` and in forks ran no checks. The Docker image took 11-17 min because arm64 was built under QEMU emulation. And the release binary did not serve the UI: it relied on an external client dir, so running it standalone showed no page on `:8080`.

## What

**Fork-friendly CI**
- Run on every branch push and on PRs to `main`/`develop`, so any fork gets CI.
- Non-blocking `race` job over `./internal/voip/...` to surface relay data races.
- Build the image on native `amd64`/`arm64` runners (no QEMU): ~11-17 min to ~3-4 min. Each repo builds and pushes to its own registry, so forks no longer fail on the upstream push.
- Bump all actions to the latest majors (checkout v7, setup-go/node v6, artifact v7/v8).

**Self-contained binary**
- `go:embed` the web client into the server and serve it when no `-static` dir is present. Running `wacalls` now opens the UI on `:8080` with no extra files.
- Release builds the client once and bakes it into the `linux`/`windows` binaries (darwin dropped).
- Dockerfile embeds the dist and drops the `-static` flag.
